### PR TITLE
Pre-compile CMS regexes and clamp expired cert DaysLeft to zero

### DIFF
--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -168,7 +168,7 @@ func detectCMS(r *Result, h http.Header, html string) {
 	// WordPress
 	if isWordPress(html) {
 		r.CMS = "WordPress"
-		if m := regexp.MustCompile(`content="wordpress\s*([\d.]+)?"`).FindStringSubmatch(html); len(m) > 1 && m[1] != "" {
+		if m := wpVersionRe.FindStringSubmatch(html); len(m) > 1 && m[1] != "" {
 			r.CMS = "WordPress " + m[1]
 		}
 		detectWPPlugins(r, html)
@@ -190,7 +190,7 @@ func detectCMS(r *Result, h http.Header, html string) {
 		return
 	}
 	// Ghost
-	if m := regexp.MustCompile(`content="ghost\s*([\d.]+)?"`).FindStringSubmatch(html); len(m) > 0 {
+	if m := ghostVersionRe.FindStringSubmatch(html); len(m) > 0 {
 		r.CMS = "Ghost"
 		if m[1] != "" {
 			r.CMS = "Ghost " + m[1]
@@ -203,12 +203,12 @@ func detectCMS(r *Result, h http.Header, html string) {
 		return
 	}
 	// Joomla
-	if strings.Contains(html, "/media/jui/") || regexp.MustCompile(`content="joomla`).MatchString(html) {
+	if strings.Contains(html, "/media/jui/") || joomlaRe.MatchString(html) {
 		r.CMS = "Joomla"
 		return
 	}
 	// Hugo
-	if regexp.MustCompile(`content="hugo`).MatchString(html) {
+	if hugoRe.MatchString(html) {
 		r.CMS = "Hugo"
 		return
 	}
@@ -370,8 +370,12 @@ func detectCSSLibs(r *Result, html string) {
 
 // parseExternalServices extracts external domains from script src and link href tags.
 var (
-	scriptSrcRe = regexp.MustCompile(`<script[^>]+src=["']([^"']+)["']`)
-	linkHrefRe  = regexp.MustCompile(`<link[^>]+href=["']([^"']+)["']`)
+	scriptSrcRe    = regexp.MustCompile(`<script[^>]+src=["']([^"']+)["']`)
+	linkHrefRe     = regexp.MustCompile(`<link[^>]+href=["']([^"']+)["']`)
+	wpVersionRe    = regexp.MustCompile(`content="wordpress\s*([\d.]+)?"`)
+	ghostVersionRe = regexp.MustCompile(`content="ghost\s*([\d.]+)?"`)
+	joomlaRe       = regexp.MustCompile(`content="joomla`)
+	hugoRe         = regexp.MustCompile(`content="hugo`)
 )
 
 func parseExternalServices(r *Result, html string, siteDomain string) {

--- a/internal/tlsinfo/tlsinfo.go
+++ b/internal/tlsinfo/tlsinfo.go
@@ -45,6 +45,11 @@ func Lookup(domain string) (*CertInfo, error) {
 	cert := certs[0]
 	now := time.Now()
 
+	daysLeft := int(cert.NotAfter.Sub(now).Hours() / 24)
+	if daysLeft < 0 {
+		daysLeft = 0
+	}
+
 	info := &CertInfo{
 		Subject:   cert.Subject.CommonName,
 		Issuer:    issuerName(cert),
@@ -54,7 +59,7 @@ func Lookup(domain string) (*CertInfo, error) {
 		Serial:    cert.SerialNumber.Text(16),
 		SigAlgo:   cert.SignatureAlgorithm.String(),
 		IsExpired: now.After(cert.NotAfter),
-		DaysLeft:  int(cert.NotAfter.Sub(now).Hours() / 24),
+		DaysLeft:  daysLeft,
 	}
 
 	info.KeyUsage = keyUsageStrings(cert)


### PR DESCRIPTION
## Summary

This PR is now intentionally scoped to the two standalone improvements called out in review:

- Pre-compile CMS detection regexes in `internal/stack/stack.go` so they are compiled once at package init instead of on each request path
- Clamp TLS `DaysLeft` to `0` for expired certificates in `internal/tlsinfo/tlsinfo.go` to avoid negative values in output

## Changes

| File | Change |
|------|--------|
| `internal/stack/stack.go` | Hoist CMS regexes (`wordpress`, `ghost`, `joomla`, `hugo`) to package-level `regexp.MustCompile` vars and reuse them in detection code |
| `internal/tlsinfo/tlsinfo.go` | Compute `daysLeft` once and clamp negative values to `0` before assigning `CertInfo.DaysLeft` |
