### PR TITLE
Fix `.it` WHOIS detection and parsing

### DIFF
--- a/internal/whois/client.go
+++ b/internal/whois/client.go
@@ -84,7 +84,9 @@ func LooksEmpty(resp string) bool {
 		strings.Contains(lower, "no match") ||
 		strings.Contains(lower, "not found") ||
 		strings.Contains(lower, "no entries found") ||
-		strings.Contains(lower, "no data found") {
+		strings.Contains(lower, "no data found") ||
+		strings.Contains(lower, "no object found") ||
+		strings.Contains(lower, "status: free") {
 		return true
 	}
 	// Check if there's at least one key: value pair with domain info
@@ -92,8 +94,18 @@ func LooksEmpty(resp string) bool {
 		line = strings.TrimSpace(line)
 		l := strings.ToLower(line)
 		if strings.HasPrefix(l, "domain name:") ||
+			strings.HasPrefix(l, "domain:") ||
 			strings.HasPrefix(l, "creation date:") ||
-			strings.HasPrefix(l, "registrar:") {
+			strings.HasPrefix(l, "created:") ||
+			strings.HasPrefix(l, "updated date:") ||
+			strings.HasPrefix(l, "last update:") ||
+			strings.HasPrefix(l, "expiry date:") ||
+			strings.HasPrefix(l, "expire date:") ||
+			strings.HasPrefix(l, "registrar:") ||
+			strings.HasPrefix(l, "status:") ||
+			strings.HasPrefix(l, "domain status:") ||
+			strings.HasPrefix(l, "name server:") ||
+			strings.HasPrefix(l, "nameserver:") {
 			return false
 		}
 	}

--- a/internal/whois/client_test.go
+++ b/internal/whois/client_test.go
@@ -1,0 +1,23 @@
+package whois
+
+import "testing"
+
+func TestLooksEmpty_ITWhoisResponse(t *testing.T) {
+	resp := `Domain:             example.it
+Status:             ok
+Created:            1998-10-29 00:00:00
+Last Update:        2026-03-05 00:53:35
+Expire Date:        2027-02-17`
+
+	if LooksEmpty(resp) {
+		t.Fatal("LooksEmpty returned true for a valid .it WHOIS response")
+	}
+}
+
+func TestLooksEmpty_NotFoundResponse(t *testing.T) {
+	resp := `No match for domain "definitely-not-registered-example-test-12345.com"`
+
+	if !LooksEmpty(resp) {
+		t.Fatal("LooksEmpty returned false for a not-found WHOIS response")
+	}
+}

--- a/internal/whois/parser.go
+++ b/internal/whois/parser.go
@@ -38,8 +38,8 @@ func Parse(raw string) model.DomainInfo {
 	info.Status = allValues(kv, "domain status", "status")
 	info.Nameservers = allValues(kv, "name server", "nameserver", "nameservers", "nserver")
 	info.CreatedDate = parseDate(firstValue(kv, "creation date", "created", "created date", "registration date", "registered on", "registered", "registration time"))
-	info.UpdatedDate = parseDate(firstValue(kv, "updated date", "last updated", "last modified", "changed"))
-	info.ExpiryDate = parseDate(firstValue(kv, "registry expiry date", "registrar registration expiration date", "expiry date", "expiration date", "expires on", "expires", "paid-till"))
+	info.UpdatedDate = parseDate(firstValue(kv, "updated date", "last update", "last updated", "last modified", "changed"))
+	info.ExpiryDate = parseDate(firstValue(kv, "registry expiry date", "registrar registration expiration date", "expire date", "expiry date", "expiration date", "expires on", "expires", "paid-till"))
 
 	dnssec := strings.ToLower(firstValue(kv, "dnssec"))
 	info.DNSSEC = dnssec == "signeddelegation" || dnssec == "yes" || dnssec == "signed"

--- a/internal/whois/parser_test.go
+++ b/internal/whois/parser_test.go
@@ -190,6 +190,29 @@ Name Server: ns1.example.com`
 	}
 }
 
+func TestParse_ITStyleFields(t *testing.T) {
+	raw := `Domain:             example.it
+Status:             ok
+Created:            1998-10-29 00:00:00
+Last Update:        2026-03-05 00:53:35
+Expire Date:        2027-02-17`
+
+	info := Parse(raw)
+
+	if info.DomainName != "example.it" {
+		t.Errorf("DomainName = %q, want example.it", info.DomainName)
+	}
+	if info.CreatedDate.Year() != 1998 {
+		t.Errorf("CreatedDate year = %d, want 1998", info.CreatedDate.Year())
+	}
+	if info.UpdatedDate.Year() != 2026 {
+		t.Errorf("UpdatedDate year = %d, want 2026", info.UpdatedDate.Year())
+	}
+	if info.ExpiryDate.Year() != 2027 {
+		t.Errorf("ExpiryDate year = %d, want 2027", info.ExpiryDate.Year())
+	}
+}
+
 func TestParseDate(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
Fix WHOIS handling for `.it` domains that use field names like `Domain`, `Created`, `Last Update`, and `Expire Date`.

Fixes #1

- Update WHOIS empty-response detection to treat `.it`-style responses as valid:
  - accepts keys like `Domain:`, `Created:`, `Last Update:`, `Expire Date:`, `Status:`
  - keeps existing “not found” heuristics
- Extend WHOIS parser aliases:
  - `last update` for `UpdatedDate`
  - `expire date` for `ExpiryDate`