### PR TITLE
IP lookups: enrich with PeeringDB and BGP-sourced ASN

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ quien --json example.com
 - **RDAP-first lookups** with WHOIS fallback for broad TLD coverage
 - **IANA referral** for automatic WHOIS server discovery
 - **Tech stack detection** including WordPress plugins, JS/CSS frameworks, and external services parsed from HTML
-- **IP lookups** with reverse DNS, network info, and abuse contacts via RDAP
+- **IP lookups** with reverse DNS, network info, abuse contacts, and ASN discovery via RDAP
+- **BGP fallback** for origin ASN/prefix when RDAP does not include ASN data
+- **PeeringDB enrichment** for ASN context (network/org, peering policy, peering locations, traffic profile, IX/facility counts)
 - **Automatic retry** with exponential backoff on all lookups
 - **JSON subcommands** for scripting: `quien dns`, `quien mail`, `quien tls`, `quien http`, `quien stack`, `quien all`
 

--- a/internal/bgp/client.go
+++ b/internal/bgp/client.go
@@ -1,0 +1,87 @@
+package bgp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://stat.ripe.net/data"
+	userAgent      = "quien/0 (+https://github.com/retlehs/quien)"
+)
+
+var (
+	baseURL = defaultBaseURL
+	client  = &http.Client{Timeout: 10 * time.Second}
+)
+
+type RouteInfo struct {
+	Resource  string
+	Prefix    string
+	OriginASN int
+	SourceID  string
+}
+
+type state struct {
+	TargetPrefix string `json:"target_prefix"`
+	Prefix       string `json:"prefix"`
+	Path         []int  `json:"path"`
+	Origin       int    `json:"origin"`
+	SourceID     string `json:"source_id"`
+}
+
+type response struct {
+	Data struct {
+		Resource string  `json:"resource"`
+		BGPState []state `json:"bgp_state"`
+	} `json:"data"`
+}
+
+// LookupIP resolves BGP route state for an IP and returns origin ASN/prefix.
+func LookupIP(ip string) (*RouteInfo, error) {
+	url := fmt.Sprintf("%s/bgp-state/data.json?resource=%s", baseURL, ip)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building bgp request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("bgp request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bgp endpoint returned status %d", resp.StatusCode)
+	}
+
+	var out response
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("parsing bgp response: %w", err)
+	}
+
+	for _, s := range out.Data.BGPState {
+		asn := s.Origin
+		if asn == 0 && len(s.Path) > 0 {
+			asn = s.Path[len(s.Path)-1]
+		}
+		if asn <= 0 {
+			continue
+		}
+		prefix := s.TargetPrefix
+		if prefix == "" {
+			prefix = s.Prefix
+		}
+		return &RouteInfo{
+			Resource:  out.Data.Resource,
+			Prefix:    prefix,
+			OriginASN: asn,
+			SourceID:  s.SourceID,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("no bgp origin ASN found for %s", ip)
+}

--- a/internal/bgp/client_test.go
+++ b/internal/bgp/client_test.go
@@ -1,0 +1,83 @@
+package bgp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLookupIP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/data/bgp-state/data.json"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("resource"), "1.1.1.1"; got != want {
+			t.Fatalf("resource = %q, want %q", got, want)
+		}
+		if got, want := r.Header.Get("User-Agent"), userAgent; got != want {
+			t.Fatalf("user-agent = %q, want %q", got, want)
+		}
+		_, _ = w.Write([]byte(`{"data":{"resource":"1.1.1.1","bgp_state":[{"target_prefix":"1.1.1.0/24","path":[13335],"source_id":"rrc00"}]}}`))
+	}))
+	defer srv.Close()
+
+	oldBaseURL := baseURL
+	baseURL = srv.URL + "/data"
+	defer func() { baseURL = oldBaseURL }()
+
+	info, err := LookupIP("1.1.1.1")
+	if err != nil {
+		t.Fatalf("LookupIP returned error: %v", err)
+	}
+	if info.OriginASN != 13335 {
+		t.Fatalf("OriginASN = %d, want 13335", info.OriginASN)
+	}
+	if info.Prefix != "1.1.1.0/24" {
+		t.Fatalf("Prefix = %q, want 1.1.1.0/24", info.Prefix)
+	}
+}
+
+func TestLookupIPNoState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"resource":"1.1.1.1","bgp_state":[]}}`))
+	}))
+	defer srv.Close()
+
+	oldBaseURL := baseURL
+	baseURL = srv.URL + "/data"
+	defer func() { baseURL = oldBaseURL }()
+
+	if _, err := LookupIP("1.1.1.1"); err == nil {
+		t.Fatal("expected error when bgp_state is empty")
+	}
+}
+
+func TestLookupIPHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	oldBaseURL := baseURL
+	baseURL = srv.URL + "/data"
+	defer func() { baseURL = oldBaseURL }()
+
+	if _, err := LookupIP("1.1.1.1"); err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+}
+
+func TestLookupIPMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"bgp_state":[`))
+	}))
+	defer srv.Close()
+
+	oldBaseURL := baseURL
+	baseURL = srv.URL + "/data"
+	defer func() { baseURL = oldBaseURL }()
+
+	if _, err := LookupIP("1.1.1.1"); err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}

--- a/internal/display/ip.go
+++ b/internal/display/ip.go
@@ -42,6 +42,12 @@ func RenderIP(info *rdap.IPInfo) string {
 	if info.Org != "" {
 		b.WriteString(row("Org", info.Org))
 	}
+	if len(info.ASN) > 0 {
+		b.WriteString(row("ASN", fmt.Sprintf("AS%d", info.ASN[0].ASN)))
+		if info.ASN[0].Name != "" {
+			b.WriteString(row("ASN Name", info.ASN[0].Name))
+		}
+	}
 	if info.Country != "" {
 		b.WriteString(row("Country", info.Country))
 	}
@@ -55,6 +61,54 @@ func RenderIP(info *rdap.IPInfo) string {
 		b.WriteString(row("Start", info.StartAddr))
 		b.WriteString(row("End", info.EndAddr))
 		b.WriteString(row("Handle", info.Handle))
+	}
+
+	if info.BGP != nil {
+		b.WriteString("\n")
+		b.WriteString(section("BGP"))
+		if info.BGP.Prefix != "" {
+			b.WriteString(row("Prefix", info.BGP.Prefix))
+		}
+	} else if info.BGPStatus != "" {
+		b.WriteString("\n")
+		b.WriteString(section("BGP"))
+		b.WriteString(row("Status", info.BGPStatus))
+	}
+
+	if info.PeeringDB != nil {
+		b.WriteString("\n")
+		b.WriteString(section("PeeringDB"))
+		if info.PeeringDB.Name != "" {
+			b.WriteString(row("Name", info.PeeringDB.Name))
+		}
+		if info.PeeringDB.NameLong != "" {
+			b.WriteString(row("Long Name", info.PeeringDB.NameLong))
+		}
+		if info.PeeringDB.Website != "" {
+			b.WriteString(row("Website", info.PeeringDB.Website))
+		}
+		if info.PeeringDB.PolicyGeneral != "" {
+			b.WriteString(row("Policy", info.PeeringDB.PolicyGeneral))
+		}
+		if info.PeeringDB.PolicyRatio != "" {
+			b.WriteString(row("Ratio", info.PeeringDB.PolicyRatio))
+		}
+		if info.PeeringDB.PolicyLocs != "" {
+			b.WriteString(row("Peering Locs", info.PeeringDB.PolicyLocs))
+		}
+		if info.PeeringDB.Traffic != "" {
+			b.WriteString(row("Traffic", info.PeeringDB.Traffic))
+		}
+		if info.PeeringDB.IXCount > 0 {
+			b.WriteString(row("IX Count", fmt.Sprintf("%d", info.PeeringDB.IXCount)))
+		}
+		if info.PeeringDB.FacilityCount > 0 {
+			b.WriteString(row("Facility Count", fmt.Sprintf("%d", info.PeeringDB.FacilityCount)))
+		}
+	} else if info.PeeringDBStatus != "" {
+		b.WriteString("\n")
+		b.WriteString(section("PeeringDB"))
+		b.WriteString(row("Status", info.PeeringDBStatus))
 	}
 
 	return b.String()

--- a/internal/peeringdb/client.go
+++ b/internal/peeringdb/client.go
@@ -1,0 +1,105 @@
+package peeringdb
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultBaseURL = "https://www.peeringdb.com/api"
+const userAgent = "quien/0 (+https://github.com/retlehs/quien)"
+
+var (
+	baseURL = defaultBaseURL
+	client  = &http.Client{Timeout: 10 * time.Second}
+)
+
+type Network struct {
+	ASN           int
+	Name          string
+	NameLong      string
+	Website       string
+	PolicyGeneral string
+	PolicyRatio   string
+	PolicyLocs    string
+	Traffic       string
+	IXCount       int
+	FacilityCount int
+}
+
+type netResponse struct {
+	Data []struct {
+		ASN           int    `json:"asn"`
+		Name          string `json:"name"`
+		NameLong      string `json:"name_long"`
+		Website       string `json:"website"`
+		PolicyGeneral string `json:"policy_general"`
+		PolicyRatio   any    `json:"policy_ratio"`
+		PolicyLocs    string `json:"policy_locations"`
+		Traffic       string `json:"info_traffic"`
+		IXCount       int    `json:"ix_count"`
+		FacilityCount int    `json:"fac_count"`
+	} `json:"data"`
+}
+
+func policyRatioValue(v any) string {
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case bool:
+		// PeeringDB may return false for unset values. Hide that from users.
+		return ""
+	case nil:
+		return ""
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", x))
+	}
+}
+
+// LookupASN fetches network details for a specific ASN from PeeringDB.
+func LookupASN(asn int) (*Network, error) {
+	if asn <= 0 {
+		return nil, fmt.Errorf("invalid ASN: %d", asn)
+	}
+
+	url := fmt.Sprintf("%s/net?asn=%d", baseURL, asn)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building peeringdb request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("peeringdb request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("peeringdb returned status %d", resp.StatusCode)
+	}
+
+	var out netResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("parsing peeringdb response: %w", err)
+	}
+	if len(out.Data) == 0 {
+		return nil, fmt.Errorf("no peeringdb record found for AS%d", asn)
+	}
+
+	n := out.Data[0]
+	return &Network{
+		ASN:           n.ASN,
+		Name:          n.Name,
+		NameLong:      n.NameLong,
+		Website:       n.Website,
+		PolicyGeneral: n.PolicyGeneral,
+		PolicyRatio:   policyRatioValue(n.PolicyRatio),
+		PolicyLocs:    n.PolicyLocs,
+		Traffic:       n.Traffic,
+		IXCount:       n.IXCount,
+		FacilityCount: n.FacilityCount,
+	}, nil
+}

--- a/internal/peeringdb/client_test.go
+++ b/internal/peeringdb/client_test.go
@@ -1,0 +1,108 @@
+package peeringdb
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLookupASN(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/net"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("asn"), "15169"; got != want {
+			t.Fatalf("asn query = %q, want %q", got, want)
+		}
+		if got, want := r.Header.Get("User-Agent"), userAgent; got != want {
+			t.Fatalf("user-agent = %q, want %q", got, want)
+		}
+		_, _ = w.Write([]byte(`{"data":[{"asn":15169,"name":"GOOGLE","name_long":"Google LLC","website":"https://google.com","policy_general":"Open","policy_ratio":false,"policy_locations":"Not Required","info_traffic":"100+Tbps","ix_count":200,"fac_count":120}]}`))
+	}))
+	defer srv.Close()
+
+	oldBaseURL := baseURL
+	baseURL = srv.URL + "/api"
+	defer func() { baseURL = oldBaseURL }()
+
+	n, err := LookupASN(15169)
+	if err != nil {
+		t.Fatalf("LookupASN returned error: %v", err)
+	}
+	if n.ASN != 15169 {
+		t.Fatalf("ASN = %d, want 15169", n.ASN)
+	}
+	if n.Name != "GOOGLE" {
+		t.Fatalf("Name = %q, want GOOGLE", n.Name)
+	}
+	if n.IXCount != 200 {
+		t.Fatalf("IXCount = %d, want 200", n.IXCount)
+	}
+	if n.PolicyRatio != "" {
+		t.Fatalf("PolicyRatio = %q, want empty for boolean false", n.PolicyRatio)
+	}
+}
+
+func TestLookupASNPolicyRatioString(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"asn":13335,"name":"Cloudflare","policy_ratio":"Balanced","ix_count":50,"fac_count":25}]}`))
+	}))
+	defer srv.Close()
+
+	oldBaseURL := baseURL
+	baseURL = srv.URL + "/api"
+	defer func() { baseURL = oldBaseURL }()
+
+	n, err := LookupASN(13335)
+	if err != nil {
+		t.Fatalf("LookupASN returned error: %v", err)
+	}
+	if n.PolicyRatio != "Balanced" {
+		t.Fatalf("PolicyRatio = %q, want Balanced", n.PolicyRatio)
+	}
+}
+
+func TestLookupASNNoData(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	oldBaseURL := baseURL
+	baseURL = srv.URL + "/api"
+	defer func() { baseURL = oldBaseURL }()
+
+	if _, err := LookupASN(64500); err == nil {
+		t.Fatal("expected error when peeringdb returns no data")
+	}
+}
+
+func TestLookupASNHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	oldBaseURL := baseURL
+	baseURL = srv.URL + "/api"
+	defer func() { baseURL = oldBaseURL }()
+
+	if _, err := LookupASN(64501); err == nil {
+		t.Fatal("expected error when peeringdb returns non-200")
+	}
+}
+
+func TestLookupASNMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[`))
+	}))
+	defer srv.Close()
+
+	oldBaseURL := baseURL
+	baseURL = srv.URL + "/api"
+	defer func() { baseURL = oldBaseURL }()
+
+	if _, err := LookupASN(64502); err == nil {
+		t.Fatal("expected error when peeringdb returns malformed JSON")
+	}
+}

--- a/internal/rdap/ip.go
+++ b/internal/rdap/ip.go
@@ -8,21 +8,28 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/retlehs/quien/internal/bgp"
+	"github.com/retlehs/quien/internal/peeringdb"
 )
 
 type IPInfo struct {
-	IP        string
-	Name      string
-	Handle    string
-	Network   string // CIDR
-	Type      string
-	Country   string
-	StartAddr string
-	EndAddr   string
-	ASN       []ASNInfo
-	Org       string
-	Abuse     string
-	Hostnames []string // reverse DNS
+	IP              string
+	Name            string
+	Handle          string
+	Network         string // CIDR
+	Type            string
+	Country         string
+	StartAddr       string
+	EndAddr         string
+	ASN             []ASNInfo
+	BGP             *bgp.RouteInfo
+	BGPStatus       string
+	PeeringDB       *peeringdb.Network
+	PeeringDBStatus string
+	Org             string
+	Abuse           string
+	Hostnames       []string // reverse DNS
 }
 
 type ASNInfo struct {
@@ -116,12 +123,73 @@ func QueryIP(ip string) (*IPInfo, error) {
 
 	info := convertIPRDAP(&rdap, ip)
 
-	// Reverse DNS
-	if names, err := net.LookupAddr(ip); err == nil {
-		for _, n := range names {
-			info.Hostnames = append(info.Hostnames, strings.TrimSuffix(n, "."))
+	asn := firstASN(info.ASN)
+	var (
+		hostnames []string
+		bgpInfo   *bgp.RouteInfo
+		peerNet   *peeringdb.Network
+		bgpStatus string
+		pdbStatus string
+		fallback  *ASNInfo
+		wg        sync.WaitGroup
+	)
+
+	// Run optional enrichment lookups concurrently to avoid serial latency.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if names, err := net.LookupAddr(ip); err == nil {
+			for _, n := range names {
+				hostnames = append(hostnames, strings.TrimSuffix(n, "."))
+			}
 		}
+	}()
+
+	if asn > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// PeeringDB is best-effort enrichment; keep base IP lookup resilient.
+			if p, err := peeringdb.LookupASN(asn); err == nil {
+				peerNet = p
+				pdbStatus = "Enriched via RDAP ASN"
+			} else {
+				pdbStatus = "Lookup failed"
+			}
+		}()
+	} else {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// BGP fallback is best-effort when RDAP lacks ASN/autnum data.
+			b, err := bgp.LookupIP(ip)
+			if err != nil {
+				bgpStatus = "Lookup failed"
+				pdbStatus = "No ASN available"
+				return
+			}
+			bgpInfo = b
+			asn = b.OriginASN
+			fallback = &ASNInfo{ASN: asn}
+
+			if p, err := peeringdb.LookupASN(asn); err == nil {
+				peerNet = p
+				pdbStatus = "Enriched via BGP ASN"
+			} else {
+				pdbStatus = "Lookup failed"
+			}
+		}()
 	}
+	wg.Wait()
+
+	info.Hostnames = hostnames
+	if fallback != nil {
+		info.ASN = append(info.ASN, *fallback)
+	}
+	info.BGP = bgpInfo
+	info.BGPStatus = bgpStatus
+	info.PeeringDB = peerNet
+	info.PeeringDBStatus = pdbStatus
 
 	return info, nil
 }
@@ -184,7 +252,27 @@ func convertIPRDAP(r *ipRDAPResponse, ip string) *IPInfo {
 		}
 	}
 
+	for _, autNum := range r.AutNums {
+		if autNum.StartAutNum <= 0 {
+			continue
+		}
+		info.ASN = append(info.ASN, ASNInfo{
+			Handle: autNum.Handle,
+			Name:   autNum.Name,
+			ASN:    autNum.StartAutNum,
+		})
+	}
+
 	return info
+}
+
+func firstASN(asns []ASNInfo) int {
+	for _, a := range asns {
+		if a.ASN > 0 {
+			return a.ASN
+		}
+	}
+	return 0
 }
 
 func extractVCardEmail(vcard []any) string {


### PR DESCRIPTION
Enriches `quien <ip>` output with ASN context from PeeringDB and a BGP-based fallback for IPs where RDAP does not include ASN data.

- **PeeringDB enrichment** by ASN adds network/org context, peering policy, peering locations, traffic profile, and IX/facility counts
- **BGP fallback** via RIPEstat’s `bgp-state` endpoint provides origin ASN and announced prefix when RDAP has no `autnums`

Both enrichments are best-effort — failures surface as a Status row and never block the base RDAP lookup.

Ref https://news.ycombinator.com/item?id=47728036