### PR TITLE
Centralize TLD quirks

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/retlehs/quien/internal/model"
 	"github.com/retlehs/quien/internal/rdap"
@@ -16,34 +17,86 @@ func LookupIP(ip string) (*rdap.IPInfo, error) {
 	})
 }
 
-// Lookup tries RDAP first, then falls back to WHOIS, with retry on each.
+// Lookup runs RDAP and WHOIS in parallel. RDAP is preferred for structured
+// data; WHOIS is used to fill in fields the registry RDAP omits (e.g. PIR/.org
+// returns no registrant entities, so we chase the registrar's WHOIS for
+// contacts) and to populate the raw view. WHOIS alone is the fallback when
+// RDAP isn't available for the TLD.
 func Lookup(domain string) (*model.DomainInfo, error) {
-	// Try RDAP first
-	if info, err := rdap.Query(domain); err == nil && info != nil {
-		// Also grab raw WHOIS for the raw tab (best effort)
-		if raw, err := whois.QueryWithReferral(domain); err == nil {
-			info.RawResponse = raw
+	var (
+		wg       sync.WaitGroup
+		rdapInfo *model.DomainInfo
+		whoisRaw string
+		whoisErr error
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		// Errors are ignored — RDAP failure just means we'll lean on WHOIS.
+		rdapInfo, _ = rdap.Query(domain)
+	}()
+	go func() {
+		defer wg.Done()
+		whoisRaw, whoisErr = retry.Do(func() (string, error) {
+			return whois.QueryWithReferral(domain)
+		})
+	}()
+	wg.Wait()
+
+	// RDAP succeeded — use it as the base, merge in any WHOIS-only fields.
+	if rdapInfo != nil {
+		if whoisErr == nil {
+			rdapInfo.RawResponse = whoisRaw
+			whoisInfo := whois.Parse(whois.Normalize(domain, whoisRaw))
+			mergeFromWhois(rdapInfo, &whoisInfo)
 		}
-		return info, nil
+		return rdapInfo, nil
 	}
 
-	// Fall back to WHOIS with retry
-	resp, err := retry.Do(func() (string, error) {
-		return whois.QueryWithReferral(domain)
-	})
-	if err != nil {
-		return nil, err
+	// RDAP unavailable — fall back to WHOIS alone.
+	if whoisErr != nil {
+		return nil, whoisErr
 	}
 
-	// Check if the response is effectively "not found"
-	if whois.LooksEmpty(resp) {
+	// Apply TLD-specific normalization (e.g. JPRS bracketed labels) before
+	// emptiness check and parsing. The original response is preserved for
+	// the raw view.
+	normalized := whois.Normalize(domain, whoisRaw)
+	if whois.LooksEmpty(normalized) {
 		return nil, fmt.Errorf("domain %s not found", domain)
 	}
 
-	info := whois.Parse(resp)
+	info := whois.Parse(normalized)
 	if info.DomainName == "" {
 		info.DomainName = domain
 	}
-	info.RawResponse = resp
+	info.RawResponse = whoisRaw
 	return &info, nil
+}
+
+// mergeFromWhois fills empty fields on the RDAP-derived info from the
+// WHOIS-parsed equivalent. RDAP wins where both have data.
+func mergeFromWhois(info *model.DomainInfo, w *model.DomainInfo) {
+	if info.Registrar == "" {
+		info.Registrar = w.Registrar
+	}
+	if len(info.Status) == 0 {
+		info.Status = w.Status
+	}
+	if len(info.Nameservers) == 0 {
+		info.Nameservers = w.Nameservers
+	}
+	if info.CreatedDate.IsZero() {
+		info.CreatedDate = w.CreatedDate
+	}
+	if info.UpdatedDate.IsZero() {
+		info.UpdatedDate = w.UpdatedDate
+	}
+	if info.ExpiryDate.IsZero() {
+		info.ExpiryDate = w.ExpiryDate
+	}
+	if len(info.Contacts) == 0 {
+		info.Contacts = w.Contacts
+	}
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1,0 +1,107 @@
+package resolver
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/retlehs/quien/internal/model"
+)
+
+func TestMergeFromWhois_FillsEmptyFields(t *testing.T) {
+	// RDAP returned only the basics — no contacts, no registrar.
+	info := &model.DomainInfo{
+		DomainName: "example.org",
+		Status:     []string{"active"},
+	}
+	whoisCreated := time.Date(2003, 3, 28, 0, 0, 0, 0, time.UTC)
+	whoisExpiry := time.Date(2035, 3, 28, 0, 0, 0, 0, time.UTC)
+	w := &model.DomainInfo{
+		Registrar:   "MarkMonitor Inc.",
+		Status:      []string{"this should be ignored"},
+		Nameservers: []string{"ns1.example.org", "ns2.example.org"},
+		CreatedDate: whoisCreated,
+		ExpiryDate:  whoisExpiry,
+		Contacts: []model.Contact{
+			{Role: "registrant", Organization: "Example Org"},
+		},
+	}
+
+	mergeFromWhois(info, w)
+
+	if info.Registrar != "MarkMonitor Inc." {
+		t.Errorf("Registrar = %q, want MarkMonitor Inc.", info.Registrar)
+	}
+	if !reflect.DeepEqual(info.Status, []string{"active"}) {
+		t.Errorf("Status = %v, want [active] (RDAP value preserved)", info.Status)
+	}
+	if !reflect.DeepEqual(info.Nameservers, []string{"ns1.example.org", "ns2.example.org"}) {
+		t.Errorf("Nameservers = %v", info.Nameservers)
+	}
+	if !info.CreatedDate.Equal(whoisCreated) {
+		t.Errorf("CreatedDate = %v, want %v", info.CreatedDate, whoisCreated)
+	}
+	if !info.ExpiryDate.Equal(whoisExpiry) {
+		t.Errorf("ExpiryDate = %v, want %v", info.ExpiryDate, whoisExpiry)
+	}
+	if len(info.Contacts) != 1 || info.Contacts[0].Organization != "Example Org" {
+		t.Errorf("Contacts = %v", info.Contacts)
+	}
+}
+
+func TestMergeFromWhois_RDAPWinsWhereBothHaveData(t *testing.T) {
+	rdapCreated := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	whoisCreated := time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC)
+	info := &model.DomainInfo{
+		DomainName:  "example.com",
+		Registrar:   "RDAP Registrar",
+		Status:      []string{"clientHold"},
+		Nameservers: []string{"a.iana-servers.net"},
+		CreatedDate: rdapCreated,
+		Contacts: []model.Contact{
+			{Role: "registrant", Name: "From RDAP"},
+		},
+	}
+	w := &model.DomainInfo{
+		Registrar:   "WHOIS Registrar",
+		Status:      []string{"ok"},
+		Nameservers: []string{"x.example"},
+		CreatedDate: whoisCreated,
+		Contacts: []model.Contact{
+			{Role: "registrant", Name: "From WHOIS"},
+		},
+	}
+
+	mergeFromWhois(info, w)
+
+	if info.Registrar != "RDAP Registrar" {
+		t.Errorf("Registrar = %q, RDAP should win", info.Registrar)
+	}
+	if !reflect.DeepEqual(info.Status, []string{"clientHold"}) {
+		t.Errorf("Status = %v, RDAP should win", info.Status)
+	}
+	if !reflect.DeepEqual(info.Nameservers, []string{"a.iana-servers.net"}) {
+		t.Errorf("Nameservers = %v, RDAP should win", info.Nameservers)
+	}
+	if !info.CreatedDate.Equal(rdapCreated) {
+		t.Errorf("CreatedDate = %v, RDAP should win", info.CreatedDate)
+	}
+	if info.Contacts[0].Name != "From RDAP" {
+		t.Errorf("Contacts[0].Name = %q, RDAP should win", info.Contacts[0].Name)
+	}
+}
+
+func TestMergeFromWhois_EmptyWhoisIsNoOp(t *testing.T) {
+	info := &model.DomainInfo{
+		DomainName: "example.com",
+		Registrar:  "Some Registrar",
+		Status:     []string{"ok"},
+	}
+	before := *info
+
+	mergeFromWhois(info, &model.DomainInfo{})
+
+	if !reflect.DeepEqual(*info, before) {
+		t.Errorf("empty WHOIS modified info: got %+v, want %+v", *info, before)
+	}
+}

--- a/internal/whois/client.go
+++ b/internal/whois/client.go
@@ -14,14 +14,25 @@ const (
 	readTimeout    = 10 * time.Second
 )
 
-// Query performs a raw WHOIS lookup for the given domain.
+// Query performs a raw WHOIS lookup for the given domain, applying any
+// TLD-specific server and query-format overrides from tlds.go.
 func Query(domain string) (string, error) {
 	server := Server(domain)
-	return QueryServer(domain, server)
+	wire := domain
+	if cfg, ok := tlds[tldOf(domain)]; ok && cfg.queryFormat != nil {
+		wire = cfg.queryFormat(domain)
+	}
+	return queryRaw(server, wire)
 }
 
-// QueryServer performs a WHOIS lookup against a specific server.
+// QueryServer performs a WHOIS lookup against a specific server, sending
+// the domain as-is. Used for IANA discovery and referral follow-ups, where
+// TLD-specific query rewriting does not apply.
 func QueryServer(domain, server string) (string, error) {
+	return queryRaw(server, domain)
+}
+
+func queryRaw(server, wire string) (string, error) {
 	addr := net.JoinHostPort(server, defaultPort)
 
 	conn, err := net.DialTimeout("tcp", addr, connectTimeout)
@@ -32,7 +43,7 @@ func QueryServer(domain, server string) (string, error) {
 
 	_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
 
-	_, err = fmt.Fprintf(conn, "%s\r\n", domain)
+	_, err = fmt.Fprintf(conn, "%s\r\n", wire)
 	if err != nil {
 		return "", fmt.Errorf("sending query: %w", err)
 	}
@@ -121,12 +132,33 @@ func extractReferral(resp string) string {
 			strings.HasPrefix(lower, "refer:") {
 			parts := strings.SplitN(line, ":", 2)
 			if len(parts) == 2 {
-				server := strings.TrimSpace(parts[1])
-				if server != "" {
+				if server := cleanReferralHost(parts[1]); server != "" {
 					return server
 				}
 			}
 		}
 	}
 	return ""
+}
+
+// cleanReferralHost normalizes a referral value into a bare hostname suitable
+// for dialing on port 43. Handles case-insensitive schemes, paths/queries, and
+// explicit :port suffixes (which would otherwise double-port via JoinHostPort).
+// WHOIS is always port 43 in practice, so any explicit port is discarded.
+func cleanReferralHost(s string) string {
+	s = strings.TrimSpace(s)
+	// Strip scheme (case-insensitive), e.g. "HTTPS://".
+	if i := strings.Index(strings.ToLower(s), "://"); i != -1 && i < 10 {
+		s = s[i+3:]
+	}
+	// Strip path, query, fragment, or trailing whitespace.
+	if i := strings.IndexAny(s, "/?# "); i != -1 {
+		s = s[:i]
+	}
+	// Strip explicit ":port" (hostnames cannot contain ':', and WHOIS
+	// referrals never use IPv6 literals).
+	if i := strings.Index(s, ":"); i != -1 {
+		s = s[:i]
+	}
+	return s
 }

--- a/internal/whois/parser.go
+++ b/internal/whois/parser.go
@@ -23,6 +23,7 @@ var dateFormats = []string{
 	"2006-01-02 15:04:05-07",
 	"Mon Jan 2 15:04:05 MST 2006",
 	"Mon Jan 2 2006",
+	"2006/01/02 15:04:05 (MST)", // JPRS Last Update
 }
 
 // Parse extracts structured domain info from a raw WHOIS response.
@@ -34,10 +35,10 @@ func Parse(raw string) model.DomainInfo {
 	kv := extractKeyValues(raw)
 
 	info.DomainName = firstValue(kv, "domain name", "domain")
-	info.Registrar = firstValue(kv, "registrar", "registrar name", "name")
+	info.Registrar = firstValue(kv, "registrar", "registrar organization", "registrar name", "name")
 	info.Status = allValues(kv, "domain status", "status")
 	info.Nameservers = allValues(kv, "name server", "nameserver", "nameservers", "nserver")
-	info.CreatedDate = parseDate(firstValue(kv, "creation date", "created", "created date", "registration date", "registered on", "registered", "registration time"))
+	info.CreatedDate = parseDate(firstValue(kv, "creation date", "created", "created date", "registration date", "registered date", "registered on", "registered", "registration time"))
 	info.UpdatedDate = parseDate(firstValue(kv, "updated date", "last update", "last updated", "last modified", "changed"))
 	info.ExpiryDate = parseDate(firstValue(kv, "registry expiry date", "registrar registration expiration date", "expire date", "expiry date", "expiration date", "expires on", "expires", "paid-till"))
 
@@ -73,34 +74,81 @@ func Parse(raw string) model.DomainInfo {
 
 func extractKeyValues(raw string) map[string][]string {
 	kv := make(map[string][]string)
-	var lastKey string
-	for _, line := range strings.Split(raw, "\n") {
+	lines := strings.Split(raw, "\n")
+	var section string // current section name (normalized, e.g. "registrar", "admin")
+	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "%") || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ">") {
-			lastKey = ""
+			section = ""
 			continue
 		}
+		indented := strings.HasPrefix(line, "\t") || strings.HasPrefix(line, " ")
 		idx := strings.Index(trimmed, ":")
+
 		if idx == -1 {
-			// Tab-indented continuation line (e.g. .be nameservers)
-			if lastKey != "" && (strings.HasPrefix(line, "\t") || strings.HasPrefix(line, "  ")) {
-				if trimmed != "" {
-					kv[lastKey] = append(kv[lastKey], trimmed)
-				}
+			if indented && section != "" {
+				// Indented value-only line inside a section (e.g. nic.it nameservers)
+				kv[section] = append(kv[section], trimmed)
+				continue
+			}
+			// Bare line — possibly a section header (e.g. nic.it "Registrar"),
+			// recognized only if the next non-blank line is indented.
+			if !indented && nextLineIndented(lines, i) {
+				section = normalizeSection(trimmed)
+			} else {
+				section = ""
 			}
 			continue
 		}
+
 		key := strings.ToLower(strings.TrimSpace(trimmed[:idx]))
 		value := strings.TrimSpace(trimmed[idx+1:])
-		if value != "" {
-			kv[key] = append(kv[key], value)
-			lastKey = ""
-		} else {
-			// Section header with no value — subsequent indented lines belong to it
-			lastKey = key
+		if value == "" {
+			// "Section:" header — subsequent indented lines belong to it
+			section = normalizeSection(trimmed[:idx])
+			continue
+		}
+		// Always record the bare key. If we're inside a section, also record
+		// a section-prefixed alias so callers can disambiguate (e.g. distinguish
+		// "registrar organization" from "registrant organization").
+		kv[key] = append(kv[key], value)
+		if indented && section != "" && section != key {
+			kv[section+" "+key] = append(kv[section+" "+key], value)
+		}
+		if !indented {
+			section = ""
 		}
 	}
 	return kv
+}
+
+func nextLineIndented(lines []string, i int) bool {
+	for j := i + 1; j < len(lines); j++ {
+		next := lines[j]
+		if strings.TrimSpace(next) == "" {
+			continue
+		}
+		return strings.HasPrefix(next, "\t") || strings.HasPrefix(next, " ")
+	}
+	return false
+}
+
+// normalizeSection maps a section header to the canonical prefix used by
+// extractContact and the field lookups (e.g. "Admin Contact" → "admin",
+// "Technical Contacts" → "tech", "Name Servers" → "nameservers").
+func normalizeSection(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimSuffix(s, " contacts")
+	s = strings.TrimSuffix(s, " contact")
+	switch s {
+	case "administrative", "admin":
+		return "admin"
+	case "technical", "tech":
+		return "tech"
+	case "name servers", "name server", "nameserver", "nameservers", "nserver":
+		return "nameservers"
+	}
+	return s
 }
 
 func firstValue(kv map[string][]string, keys ...string) string {

--- a/internal/whois/parser_test.go
+++ b/internal/whois/parser_test.go
@@ -213,6 +213,74 @@ Expire Date:        2027-02-17`
 	}
 }
 
+func TestParse_NicITSectionedFormat(t *testing.T) {
+	raw := `Domain:             example.it
+Status:             ok
+
+Registrant
+  Organization:     hidden
+
+Admin Contact
+  Name:             alice hidden
+  Organization:     hidden
+
+Technical Contacts
+  Name:             bob hidden
+  Organization:     hidden
+
+Registrar
+  Organization:     NameCase GmbH
+  Name:             NAMECASE-REG
+  DNSSEC:           no
+
+Nameservers
+  ns1.nidomans.com
+  ns2.nidomans.com`
+
+	info := Parse(raw)
+
+	if info.Registrar != "NameCase GmbH" {
+		t.Errorf("Registrar = %q, want NameCase GmbH (registrar org should beat registrant org)", info.Registrar)
+	}
+	if len(info.Nameservers) != 2 || info.Nameservers[0] != "ns1.nidomans.com" {
+		t.Errorf("Nameservers = %v, want [ns1.nidomans.com ns2.nidomans.com]", info.Nameservers)
+	}
+	// Section-prefixed aliases should disambiguate name fields too.
+	var admin, tech *string
+	for i := range info.Contacts {
+		switch info.Contacts[i].Role {
+		case "admin":
+			admin = &info.Contacts[i].Name
+		case "tech":
+			tech = &info.Contacts[i].Name
+		}
+	}
+	if admin == nil || *admin != "alice hidden" {
+		t.Errorf("admin contact name = %v, want alice hidden", admin)
+	}
+	if tech == nil || *tech != "bob hidden" {
+		t.Errorf("tech contact name = %v, want bob hidden", tech)
+	}
+}
+
+func TestParse_StateFieldDoesNotPolluteStatus(t *testing.T) {
+	// Indented "State: CA" inside a contact block (US state, not domain
+	// status) must not end up in info.Status.
+	raw := `Domain Name: example.com
+Domain Status: ok
+Registrant Name: Foo
+  State: CA
+  Country: US`
+
+	info := Parse(raw)
+
+	for _, s := range info.Status {
+		if s == "CA" {
+			t.Errorf("info.Status contains %q — geographic State leaked into Status", s)
+		}
+	}
+}
+
 func TestParseDate(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/whois/servers.go
+++ b/internal/whois/servers.go
@@ -7,14 +7,13 @@ import (
 )
 
 // Server returns the WHOIS server for the given TLD.
-// Resolution order: hardcoded map → IANA referral → whois.nic.{tld} guess.
+// Resolution order: hardcoded tlds map → IANA referral → whois.nic.{tld} guess.
 func Server(domain string) string {
-	parts := strings.Split(domain, ".")
-	tld := strings.ToLower(parts[len(parts)-1])
+	tld := tldOf(domain)
 
-	// 1. Check hardcoded map
-	if server, ok := tldServers[tld]; ok {
-		return server
+	// 1. Check hardcoded TLD config
+	if cfg, ok := tlds[tld]; ok && cfg.server != "" {
+		return cfg.server
 	}
 
 	// 2. Check IANA referral cache
@@ -74,12 +73,6 @@ var ianaCache = struct {
 	sync.RWMutex
 	m map[string]string
 }{m: make(map[string]string)}
-
-var tldServers = map[string]string{
-	"com": "whois.verisign-grs.com",
-	"net": "whois.verisign-grs.com",
-	"org": "whois.pir.org",
-}
 
 // PrintServer is a debug helper — prints what server would be used.
 func PrintServer(domain string) string {

--- a/internal/whois/tlds.go
+++ b/internal/whois/tlds.go
@@ -1,0 +1,89 @@
+package whois
+
+import (
+	"regexp"
+	"strings"
+)
+
+// tldConfig holds per-TLD overrides for WHOIS lookups. All fields are optional.
+type tldConfig struct {
+	// server overrides the IANA-discovered WHOIS server. Empty = ask IANA.
+	server string
+	// queryFormat rewrites the wire query for servers with non-standard syntax.
+	// Nil = send the domain as-is.
+	queryFormat func(domain string) string
+	// normalize rewrites a raw response into the generic "key: value" form
+	// the parser expects. Nil = pass through unchanged.
+	normalize func(raw string) string
+}
+
+// tlds is the single source of truth for TLD-specific WHOIS quirks.
+var tlds = map[string]tldConfig{
+	"com": {server: "whois.verisign-grs.com"},
+	"net": {server: "whois.verisign-grs.com"},
+	"org": {server: "whois.pir.org"},
+	// DENIC returns only Domain + Status without the "-T dn" prefix.
+	"de": {server: "whois.denic.de", queryFormat: func(d string) string { return "-T dn " + d }},
+	// JPRS returns Japanese by default; "/e" requests English. The English
+	// response uses bracketed labels (`[Domain Name]   value`) instead of
+	// the conventional "key: value" form, so we rewrite it for the parser.
+	"jp": {
+		server:      "whois.jprs.jp",
+		queryFormat: func(d string) string { return d + "/e" },
+		normalize:   normalizeJPRS,
+	},
+	// .co.jp, .ne.jp, etc. all use the same JPRS server.
+}
+
+// Normalize applies any TLD-specific transformation that brings the raw
+// response in line with the generic "key: value" parser. Unknown TLDs and
+// TLDs without a normalizer pass through unchanged.
+func Normalize(domain, raw string) string {
+	cfg, ok := tlds[tldOf(domain)]
+	if !ok || cfg.normalize == nil {
+		return raw
+	}
+	return cfg.normalize(raw)
+}
+
+func tldOf(domain string) string {
+	parts := strings.Split(domain, ".")
+	return strings.ToLower(parts[len(parts)-1])
+}
+
+// jprsLabelLine matches a JPRS English-format data line:
+//
+//	a. [Domain Name]                GOOGLE.CO.JP
+//	[State]                         Connected (2027/03/31)
+//
+// The optional "a. " prefix is a JPRS field code. Banner lines like
+// "[ JPRS database ... ]" don't match because the label cannot start with
+// whitespace, and lines with no value after the closing bracket are skipped.
+var jprsLabelLine = regexp.MustCompile(`^\s*(?:[a-z]\.\s+)?\[([^\s\]][^\]]*)\]\s+(\S.*)$`)
+
+// jprsLabelRenames maps JPRS-specific label names to the canonical key the
+// generic parser already understands. Only labels that don't already match
+// a generic name need to appear here.
+var jprsLabelRenames = map[string]string{
+	"state": "Status", // JPRS uses "State" for domain lifecycle (Connected/...)
+}
+
+func normalizeJPRS(raw string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(raw, "\n") {
+		if m := jprsLabelLine.FindStringSubmatch(line); m != nil {
+			label := strings.TrimSpace(m[1])
+			if rename, ok := jprsLabelRenames[strings.ToLower(label)]; ok {
+				label = rename
+			}
+			b.WriteString(label)
+			b.WriteString(": ")
+			b.WriteString(strings.TrimSpace(m[2]))
+			b.WriteByte('\n')
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/internal/whois/tlds_test.go
+++ b/internal/whois/tlds_test.go
@@ -1,0 +1,139 @@
+package whois
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTLDQueryFormat(t *testing.T) {
+	tests := []struct {
+		domain string
+		want   string
+	}{
+		{"example.de", "-T dn example.de"}, // DENIC requires -T dn
+		{"google.co.jp", "google.co.jp/e"}, // JPRS needs /e for English
+		{"example.com", "example.com"},     // .com has no queryFormat override
+		{"example.invalidtld", "example.invalidtld"},
+	}
+	for _, tt := range tests {
+		cfg, ok := tlds[tldOf(tt.domain)]
+		var got string
+		if ok && cfg.queryFormat != nil {
+			got = cfg.queryFormat(tt.domain)
+		} else {
+			got = tt.domain
+		}
+		if got != tt.want {
+			t.Errorf("queryFormat(%q) = %q, want %q", tt.domain, got, tt.want)
+		}
+	}
+}
+
+func TestTLDServerOverrides(t *testing.T) {
+	tests := map[string]string{
+		"example.com":  "whois.verisign-grs.com",
+		"example.net":  "whois.verisign-grs.com",
+		"example.org":  "whois.pir.org",
+		"example.de":   "whois.denic.de",
+		"google.co.jp": "whois.jprs.jp",
+	}
+	for domain, want := range tests {
+		cfg, ok := tlds[tldOf(domain)]
+		if !ok || cfg.server != want {
+			t.Errorf("tlds[%q].server = %q, want %q", tldOf(domain), cfg.server, want)
+		}
+	}
+}
+
+func TestNormalize_PassThroughForUnknownTLD(t *testing.T) {
+	raw := "Domain Name: example.com\n"
+	got := Normalize("example.com", raw)
+	if got != raw {
+		t.Errorf("Normalize() modified .com response (should pass through)")
+	}
+}
+
+func TestNormalizeJPRS(t *testing.T) {
+	raw := `[ JPRS database provides information on network administration. ]
+[ Banner text continues here.                                  ]
+Domain Information:
+a. [Domain Name]                GOOGLE.CO.JP
+g. [Organization]               Google Japan G.K.
+p. [Name Server]                ns1.google.com
+p. [Name Server]                ns2.google.com
+s. [Signing Key]
+[State]                         Connected (2027/03/31)
+[Registered Date]               2001/03/22
+[Last Update]                   2026/04/01 01:02:00 (JST)`
+
+	out := normalizeJPRS(raw)
+
+	mustContain := []string{
+		"Domain Name: GOOGLE.CO.JP",
+		"Name Server: ns1.google.com",
+		"Name Server: ns2.google.com",
+		"Status: Connected (2027/03/31)", // [State] renamed to Status
+		"Registered Date: 2001/03/22",
+		"Last Update: 2026/04/01 01:02:00 (JST)",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("normalized output missing %q\n--- output ---\n%s", s, out)
+		}
+	}
+	// Banner [ ... ] lines must NOT be turned into key:value pairs.
+	if strings.Contains(out, "JPRS database") && strings.Contains(out, "JPRS database:") {
+		t.Errorf("banner line was rewritten as a key: value pair")
+	}
+	// Empty-value lines like "[Signing Key]" must be skipped, not produce "Signing Key: ".
+	if strings.Contains(out, "Signing Key:") {
+		t.Errorf("empty-value line was emitted")
+	}
+
+	// Round-trip through Parse to make sure the renamed fields get picked up.
+	info := Parse(out)
+	if len(info.Status) == 0 || info.Status[0] != "Connected (2027/03/31)" {
+		t.Errorf("Parse(normalized).Status = %v, want [Connected (2027/03/31)]", info.Status)
+	}
+	if info.CreatedDate.Year() != 2001 {
+		t.Errorf("Parse(normalized).CreatedDate year = %d, want 2001", info.CreatedDate.Year())
+	}
+	if info.UpdatedDate.Year() != 2026 {
+		t.Errorf("Parse(normalized).UpdatedDate year = %d, want 2026", info.UpdatedDate.Year())
+	}
+	if len(info.Nameservers) != 2 {
+		t.Errorf("Parse(normalized).Nameservers count = %d, want 2", len(info.Nameservers))
+	}
+}
+
+func TestCleanReferralHost(t *testing.T) {
+	tests := map[string]string{
+		// Bare hostname — unchanged.
+		"whois.markmonitor.com": "whois.markmonitor.com",
+		// Standard schemes.
+		"http://whois.markmonitor.com":  "whois.markmonitor.com",
+		"https://whois.markmonitor.com": "whois.markmonitor.com",
+		// Mixed-case scheme (RFC says scheme is case-insensitive).
+		"HTTPS://whois.markmonitor.com": "whois.markmonitor.com",
+		"Http://whois.example.com":      "whois.example.com",
+		// Whitespace.
+		"  whois.example.com  ": "whois.example.com",
+		// Path / query / fragment.
+		"https://whois.example.com/path":    "whois.example.com",
+		"https://whois.example.com/p?q=1":   "whois.example.com",
+		"https://whois.example.com#section": "whois.example.com",
+		"  https://whois.example.com/path ": "whois.example.com",
+		// Explicit :port — must be stripped, otherwise JoinHostPort double-ports.
+		"whois.example.com:43":         "whois.example.com",
+		"whois.example.com:4343":       "whois.example.com",
+		"https://whois.example.com:43": "whois.example.com",
+		"http://whois.example.com:43/": "whois.example.com",
+		// Empty.
+		"": "",
+	}
+	for in, want := range tests {
+		if got := cleanReferralHost(in); got != want {
+			t.Errorf("cleanReferralHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
- New `internal/whois/tlds.go` holds per-TLD WHOIS server, query format, and response normalizer in one map.
- `.de`: send `-T dn <domain>` so DENIC returns nameservers and changed date.
- `.jp`: query JPRS with `/e` and normalize bracketed labels into `key: value` form.
- `.it`: parser handles bare section headers with indented sub-fields, so registrar info no longer collides with registrant info.
- `.org`: strip URL schemes/ports from registrar referral hosts so we actually reach the registrar WHOIS.
- Resolver runs RDAP and WHOIS in parallel and merges them; RDAP wins where both have data.

Ref #7 
Ref #6 
Ref #2 