### PR TITLE
Normalize WHOIS targets and reject non-domain inputs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,10 +16,11 @@ import (
 var jsonFlag bool
 
 var rootCmd = &cobra.Command{
-	Use:   "quien [domain or IP]",
-	Short: "A better WHOIS lookup tool",
-	Long:  "quien queries WHOIS/RDAP information for a domain or IP address and displays it in a clean, readable format.",
-	Args:  cobra.MaximumNArgs(1),
+	Use:          "quien [domain or IP]",
+	Short:        "A better WHOIS lookup tool",
+	Long:         "quien queries WHOIS/RDAP information for a domain or IP address and displays it in a clean, readable format.",
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// No args — show interactive prompt
 		if len(args) == 0 {
@@ -66,6 +67,11 @@ var rootCmd = &cobra.Command{
 }
 
 func runLookup(input string, isIP bool) error {
+	if !isIP {
+		if _, err := resolver.RegistrableDomain(input); err != nil {
+			return err
+		}
+	}
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		var m display.Model
 		if isIP {

--- a/internal/resolver/normalize.go
+++ b/internal/resolver/normalize.go
@@ -1,0 +1,43 @@
+package resolver
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// RegistrableDomain returns the effective TLD+1 for s — the registrable
+// domain that a WHOIS/RDAP registry will actually answer queries for.
+// For "mail.google.com" it returns "google.com"; for "sub.example.co.jp" it
+// returns "example.co.jp"; for "example.com" it returns "example.com".
+//
+// Inputs that clearly aren't domains ("hello", "version", bare suffixes like
+// "co.jp", anything without a dot) return an error so callers can reject them
+// cleanly instead of dispatching a doomed WHOIS query.
+func RegistrableDomain(s string) (string, error) {
+	if len(s) < 3 || len(s) > 253 {
+		return "", fmt.Errorf("%q is not a valid domain", s)
+	}
+	if !strings.Contains(s, ".") {
+		return "", fmt.Errorf("%q is not a valid domain", s)
+	}
+	suffix, icann := publicsuffix.PublicSuffix(s)
+	if icann {
+		d, err := publicsuffix.EffectiveTLDPlusOne(s)
+		if err != nil {
+			return "", fmt.Errorf("%q is not a valid domain", s)
+		}
+		return d, nil
+	}
+	// !icann means the matched suffix is either a private suffix
+	// (e.g. github.io, netlify.app) or the fallback single-label rule for
+	// unknown TLDs. A multi-label private suffix is itself the registrable
+	// domain — that's what the domain owner actually registered at the
+	// ICANN registry. A single-label !icann match (e.g. "bar" from foo.bar)
+	// means we don't recognize the TLD and should reject.
+	if strings.Contains(suffix, ".") {
+		return suffix, nil
+	}
+	return "", fmt.Errorf("%q is not a valid domain", s)
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -23,6 +23,12 @@ func LookupIP(ip string) (*rdap.IPInfo, error) {
 // contacts) and to populate the raw view. WHOIS alone is the fallback when
 // RDAP isn't available for the TLD.
 func Lookup(domain string) (*model.DomainInfo, error) {
+	target, err := RegistrableDomain(domain)
+	if err != nil {
+		return nil, err
+	}
+	domain = target
+
 	var (
 		wg       sync.WaitGroup
 		rdapInfo *model.DomainInfo


### PR DESCRIPTION
- `resolver.RegistrableDomain` normalizes WHOIS/RDAP targets via the public suffix list so subdomain queries walk up to the registrable domain (`mail.google.com` → `google.com`, `retlehs.github.io` → `github.io`). Subcommands like `dns`, `tls`, and `mail` still pass the raw FQDN through so they query exactly the name you typed.
- Obvious non-domains (`hello`, `version`, bare suffixes like `co.jp`) are rejected before the TUI launches, and `rootCmd.SilenceUsage` keeps those errors to a single line instead of dumping cobra's usage help.
