### PR TITLE
Fix TCP fallback for truncated DNS responses

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -156,6 +156,14 @@ func query(domain string, qtype uint16, resolver string) ([]mdns.RR, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Retry over TCP when the UDP response is truncated.
+	if resp.Truncated {
+		tcpClient := &mdns.Client{Timeout: timeout, Net: "tcp"}
+		resp, _, err = tcpClient.Exchange(msg, resolver)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if resp.Rcode != mdns.RcodeSuccess {
 		return nil, fmt.Errorf("DNS query failed: %s", mdns.RcodeToString[resp.Rcode])
 	}

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -21,7 +21,7 @@ func startTruncatingDNSServer(t *testing.T, domain string, records []string) str
 
 	tcpLn, err := net.Listen("tcp", udpAddr)
 	if err != nil {
-		udpConn.Close()
+		_ = udpConn.Close()
 		t.Fatal(err)
 	}
 
@@ -37,7 +37,7 @@ func startTruncatingDNSServer(t *testing.T, domain string, records []string) str
 				})
 			}
 		}
-		w.WriteMsg(m)
+		_ = w.WriteMsg(m)
 	})
 
 	// UDP handler — always sets TC (truncated) flag with an empty answer.
@@ -45,18 +45,18 @@ func startTruncatingDNSServer(t *testing.T, domain string, records []string) str
 		m := new(mdns.Msg)
 		m.SetReply(r)
 		m.Truncated = true
-		w.WriteMsg(m)
+		_ = w.WriteMsg(m)
 	})
 
 	tcpServer := &mdns.Server{Listener: tcpLn, Handler: tcpHandler, Net: "tcp"}
 	udpServer := &mdns.Server{PacketConn: udpConn, Handler: udpHandler, Net: "udp"}
 
-	go tcpServer.ActivateAndServe()
-	go udpServer.ActivateAndServe()
+	go func() { _ = tcpServer.ActivateAndServe() }()
+	go func() { _ = udpServer.ActivateAndServe() }()
 
 	t.Cleanup(func() {
-		tcpServer.Shutdown()
-		udpServer.Shutdown()
+		_ = tcpServer.Shutdown()
+		_ = udpServer.Shutdown()
 	})
 
 	return udpAddr
@@ -98,11 +98,11 @@ func TestQueryUDPSuccessSkipsTCPFallback(t *testing.T) {
 				Txt: []string{txt},
 			})
 		}
-		w.WriteMsg(m)
+		_ = w.WriteMsg(m)
 	})
 	server := &mdns.Server{PacketConn: conn, Handler: handler, Net: "udp"}
-	go server.ActivateAndServe()
-	t.Cleanup(func() { server.Shutdown() })
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
 
 	addr := conn.LocalAddr().String()
 	rr, err := query(domain, mdns.TypeTXT, addr)

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -1,0 +1,115 @@
+package dns
+
+import (
+	"net"
+	"testing"
+
+	mdns "github.com/miekg/dns"
+)
+
+// startTruncatingDNSServer spins up a local UDP+TCP DNS server that returns
+// a truncated UDP response (TC flag set, empty answer) but a full answer
+// over TCP.
+func startTruncatingDNSServer(t *testing.T, domain string, records []string) string {
+	t.Helper()
+
+	udpConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	udpAddr := udpConn.LocalAddr().String()
+
+	tcpLn, err := net.Listen("tcp", udpAddr)
+	if err != nil {
+		udpConn.Close()
+		t.Fatal(err)
+	}
+
+	// TCP handler — returns all records.
+	tcpHandler := mdns.HandlerFunc(func(w mdns.ResponseWriter, r *mdns.Msg) {
+		m := new(mdns.Msg)
+		m.SetReply(r)
+		if r.Question[0].Qtype == mdns.TypeTXT {
+			for _, rec := range records {
+				m.Answer = append(m.Answer, &mdns.TXT{
+					Hdr: mdns.RR_Header{Name: domain, Rrtype: mdns.TypeTXT, Class: mdns.ClassINET, Ttl: 60},
+					Txt: []string{rec},
+				})
+			}
+		}
+		w.WriteMsg(m)
+	})
+
+	// UDP handler — always sets TC (truncated) flag with an empty answer.
+	udpHandler := mdns.HandlerFunc(func(w mdns.ResponseWriter, r *mdns.Msg) {
+		m := new(mdns.Msg)
+		m.SetReply(r)
+		m.Truncated = true
+		w.WriteMsg(m)
+	})
+
+	tcpServer := &mdns.Server{Listener: tcpLn, Handler: tcpHandler, Net: "tcp"}
+	udpServer := &mdns.Server{PacketConn: udpConn, Handler: udpHandler, Net: "udp"}
+
+	go tcpServer.ActivateAndServe()
+	go udpServer.ActivateAndServe()
+
+	t.Cleanup(func() {
+		tcpServer.Shutdown()
+		udpServer.Shutdown()
+	})
+
+	return udpAddr
+}
+
+func TestQueryTCPFallbackOnTruncation(t *testing.T) {
+	domain := "example.com."
+	txtRecords := []string{
+		"v=spf1 include:_spf.google.com ~all",
+		"google-site-verification=abc123",
+		"MS=ms12345",
+	}
+	resolver := startTruncatingDNSServer(t, domain, txtRecords)
+
+	rr, err := query(domain, mdns.TypeTXT, resolver)
+	if err != nil {
+		t.Fatalf("query returned error: %v", err)
+	}
+
+	if len(rr) != len(txtRecords) {
+		t.Errorf("expected %d TXT records, got %d", len(txtRecords), len(rr))
+	}
+}
+
+func TestQueryUDPSuccessSkipsTCPFallback(t *testing.T) {
+	domain := "small.example."
+	txt := "v=spf1 -all"
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := mdns.HandlerFunc(func(w mdns.ResponseWriter, r *mdns.Msg) {
+		m := new(mdns.Msg)
+		m.SetReply(r)
+		if r.Question[0].Qtype == mdns.TypeTXT {
+			m.Answer = append(m.Answer, &mdns.TXT{
+				Hdr: mdns.RR_Header{Name: domain, Rrtype: mdns.TypeTXT, Class: mdns.ClassINET, Ttl: 60},
+				Txt: []string{txt},
+			})
+		}
+		w.WriteMsg(m)
+	})
+	server := &mdns.Server{PacketConn: conn, Handler: handler, Net: "udp"}
+	go server.ActivateAndServe()
+	t.Cleanup(func() { server.Shutdown() })
+
+	addr := conn.LocalAddr().String()
+	rr, err := query(domain, mdns.TypeTXT, addr)
+	if err != nil {
+		t.Fatalf("query returned error: %v", err)
+	}
+	if len(rr) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(rr))
+	}
+}

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -159,6 +159,14 @@ func query(name string, qtype uint16, resolver string) ([]mdns.RR, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Retry over TCP when the UDP response is truncated.
+	if resp.Truncated {
+		tcpClient := &mdns.Client{Timeout: timeout, Net: "tcp"}
+		resp, _, err = tcpClient.Exchange(msg, resolver)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if resp.Rcode != mdns.RcodeSuccess {
 		return nil, fmt.Errorf("DNS query failed: %s", mdns.RcodeToString[resp.Rcode])
 	}

--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -1,0 +1,122 @@
+package mail
+
+import (
+	"net"
+	"testing"
+
+	mdns "github.com/miekg/dns"
+)
+
+// startTruncatingDNSServer spins up a local UDP+TCP DNS server that returns
+// a truncated UDP response (TC flag set, empty answer) but a full answer
+// over TCP. This simulates the real-world scenario where many TXT records
+// exceed the 512-byte UDP limit.
+func startTruncatingDNSServer(t *testing.T, domain, spfRecord string) string {
+	t.Helper()
+
+	udpConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	udpAddr := udpConn.LocalAddr().String()
+
+	tcpLn, err := net.Listen("tcp", udpAddr)
+	if err != nil {
+		udpConn.Close()
+		t.Fatal(err)
+	}
+
+	// TCP handler — returns all records.
+	tcpHandler := mdns.HandlerFunc(func(w mdns.ResponseWriter, r *mdns.Msg) {
+		m := new(mdns.Msg)
+		m.SetReply(r)
+		if r.Question[0].Qtype == mdns.TypeTXT {
+			m.Answer = append(m.Answer, &mdns.TXT{
+				Hdr: mdns.RR_Header{Name: domain, Rrtype: mdns.TypeTXT, Class: mdns.ClassINET, Ttl: 60},
+				Txt: []string{spfRecord},
+			})
+		}
+		w.WriteMsg(m)
+	})
+
+	// UDP handler — always sets TC (truncated) flag with an empty answer.
+	udpHandler := mdns.HandlerFunc(func(w mdns.ResponseWriter, r *mdns.Msg) {
+		m := new(mdns.Msg)
+		m.SetReply(r)
+		m.Truncated = true
+		w.WriteMsg(m)
+	})
+
+	tcpServer := &mdns.Server{Listener: tcpLn, Handler: tcpHandler, Net: "tcp"}
+	udpServer := &mdns.Server{PacketConn: udpConn, Handler: udpHandler, Net: "udp"}
+
+	go tcpServer.ActivateAndServe()
+	go udpServer.ActivateAndServe()
+
+	t.Cleanup(func() {
+		tcpServer.Shutdown()
+		udpServer.Shutdown()
+	})
+
+	return udpAddr
+}
+
+func TestQueryTCPFallbackOnTruncation(t *testing.T) {
+	domain := "example.com."
+	spf := "v=spf1 include:_spf.google.com ~all"
+	resolver := startTruncatingDNSServer(t, domain, spf)
+
+	rr, err := query(domain, mdns.TypeTXT, resolver)
+	if err != nil {
+		t.Fatalf("query returned error: %v", err)
+	}
+
+	var found string
+	for _, r := range rr {
+		if txt, ok := r.(*mdns.TXT); ok {
+			for _, s := range txt.Txt {
+				if s == spf {
+					found = s
+				}
+			}
+		}
+	}
+
+	if found == "" {
+		t.Errorf("expected SPF record %q in TCP response, got none", spf)
+	}
+}
+
+func TestQueryUDPSuccessSkipsTCPFallback(t *testing.T) {
+	domain := "small.example."
+	spf := "v=spf1 -all"
+
+	// Server that returns a full answer over UDP (no truncation).
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := mdns.HandlerFunc(func(w mdns.ResponseWriter, r *mdns.Msg) {
+		m := new(mdns.Msg)
+		m.SetReply(r)
+		if r.Question[0].Qtype == mdns.TypeTXT {
+			m.Answer = append(m.Answer, &mdns.TXT{
+				Hdr: mdns.RR_Header{Name: domain, Rrtype: mdns.TypeTXT, Class: mdns.ClassINET, Ttl: 60},
+				Txt: []string{spf},
+			})
+		}
+		w.WriteMsg(m)
+	})
+	server := &mdns.Server{PacketConn: conn, Handler: handler, Net: "udp"}
+	go server.ActivateAndServe()
+	t.Cleanup(func() { server.Shutdown() })
+
+	addr := conn.LocalAddr().String()
+	rr, err := query(domain, mdns.TypeTXT, addr)
+	if err != nil {
+		t.Fatalf("query returned error: %v", err)
+	}
+	if len(rr) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(rr))
+	}
+}

--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -22,7 +22,7 @@ func startTruncatingDNSServer(t *testing.T, domain, spfRecord string) string {
 
 	tcpLn, err := net.Listen("tcp", udpAddr)
 	if err != nil {
-		udpConn.Close()
+		_ = udpConn.Close()
 		t.Fatal(err)
 	}
 
@@ -36,7 +36,7 @@ func startTruncatingDNSServer(t *testing.T, domain, spfRecord string) string {
 				Txt: []string{spfRecord},
 			})
 		}
-		w.WriteMsg(m)
+		_ = w.WriteMsg(m)
 	})
 
 	// UDP handler — always sets TC (truncated) flag with an empty answer.
@@ -44,18 +44,18 @@ func startTruncatingDNSServer(t *testing.T, domain, spfRecord string) string {
 		m := new(mdns.Msg)
 		m.SetReply(r)
 		m.Truncated = true
-		w.WriteMsg(m)
+		_ = w.WriteMsg(m)
 	})
 
 	tcpServer := &mdns.Server{Listener: tcpLn, Handler: tcpHandler, Net: "tcp"}
 	udpServer := &mdns.Server{PacketConn: udpConn, Handler: udpHandler, Net: "udp"}
 
-	go tcpServer.ActivateAndServe()
-	go udpServer.ActivateAndServe()
+	go func() { _ = tcpServer.ActivateAndServe() }()
+	go func() { _ = udpServer.ActivateAndServe() }()
 
 	t.Cleanup(func() {
-		tcpServer.Shutdown()
-		udpServer.Shutdown()
+		_ = tcpServer.Shutdown()
+		_ = udpServer.Shutdown()
 	})
 
 	return udpAddr
@@ -105,11 +105,11 @@ func TestQueryUDPSuccessSkipsTCPFallback(t *testing.T) {
 				Txt: []string{spf},
 			})
 		}
-		w.WriteMsg(m)
+		_ = w.WriteMsg(m)
 	})
 	server := &mdns.Server{PacketConn: conn, Handler: handler, Net: "udp"}
-	go server.ActivateAndServe()
-	t.Cleanup(func() { server.Shutdown() })
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
 
 	addr := conn.LocalAddr().String()
 	rr, err := query(domain, mdns.TypeTXT, addr)


### PR DESCRIPTION
## Summary

- **Bug**: `query()` in both `internal/dns` and `internal/mail` uses UDP only. Domains with many TXT records (e.g. 9+ records, >512 bytes) cause the DNS server to set the TC (truncated) flag. Records near the end of the response — often SPF — are silently dropped.
- **Fix**: Check `resp.Truncated` after the UDP exchange and retry over TCP, matching the behavior of `dig` and other standard resolvers.
- **Tests**: Added `mail_test.go` and `dns_test.go` with local mock DNS servers that simulate truncation, verifying the TCP fallback path and the no-truncation fast path.

## Reproduction

```bash
# Shows SPF is present:
dig +short TXT staffbase.com | grep spf

# Shows empty SPF field — response is 603 bytes, truncated over UDP:
quien mail staffbase.com | jq .SPF
```

## Test plan

- [x] `go test ./internal/mail/ -run TestQuery -v` — TCP fallback and UDP-only paths pass
- [x] `go test ./internal/dns/ -run TestQuery -v` — same
- [x] `go test ./...` — full suite (147 tests), zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)