### PR TITLE
Show issuer organization in TLS certificate display

### DIFF
--- a/internal/tlsinfo/tlsinfo.go
+++ b/internal/tlsinfo/tlsinfo.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -46,7 +47,7 @@ func Lookup(domain string) (*CertInfo, error) {
 
 	info := &CertInfo{
 		Subject:   cert.Subject.CommonName,
-		Issuer:    cert.Issuer.CommonName,
+		Issuer:    issuerName(cert),
 		NotBefore: cert.NotBefore,
 		NotAfter:  cert.NotAfter,
 		SANs:      cert.DNSNames,
@@ -74,4 +75,17 @@ func keyUsageStrings(cert *x509.Certificate) []string {
 		}
 	}
 	return usages
+}
+
+func issuerName(cert *x509.Certificate) string {
+	cn := cert.Issuer.CommonName
+	org := strings.Join(cert.Issuer.Organization, ", ")
+	switch {
+	case org != "" && cn != "" && !strings.EqualFold(org, cn):
+		return org + " " + cn
+	case org != "":
+		return org
+	default:
+		return cn
+	}
 }

--- a/internal/tlsinfo/tlsinfo_test.go
+++ b/internal/tlsinfo/tlsinfo_test.go
@@ -1,0 +1,39 @@
+package tlsinfo
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+)
+
+func TestIssuerName(t *testing.T) {
+	tests := []struct {
+		name string
+		org  []string
+		cn   string
+		want string
+	}{
+		{"org and cn differ", []string{"Let's Encrypt"}, "E8", "Let's Encrypt E8"},
+		{"cn only", nil, "R3", "R3"},
+		{"org only", []string{"DigiCert Inc"}, "", "DigiCert Inc"},
+		{"org equals cn", []string{"CloudFlare"}, "CloudFlare", "CloudFlare"},
+		{"org equals cn case insensitive", []string{"Cloudflare"}, "CLOUDFLARE", "Cloudflare"},
+		{"both empty", nil, "", ""},
+		{"multiple orgs", []string{"Org A", "Org B"}, "CN", "Org A, Org B CN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert := &x509.Certificate{
+				Issuer: pkix.Name{
+					Organization: tt.org,
+					CommonName:   tt.cn,
+				},
+			}
+			got := issuerName(cert)
+			if got != tt.want {
+				t.Errorf("issuerName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Display issuer as "Org CN" when both fields are present and differ (e.g. "Let's Encrypt E8" instead of just "E8")
- Falls back to org-only or CN-only when one is missing
- Case-insensitive dedup when org and CN match

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)