### PR TITLE
Add adaptive color palette for light terminal themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ The CrUX API is free. Not all domains have field data — a site needs enough Ch
 
 </details>
 
+## Theme
+
+quien automatically detects your terminal background and picks light or dark colors. If detection gets it wrong (common in tmux, screen, or remote shells), override it:
+
+```sh
+export QUIEN_THEME=light  # force light palette
+export QUIEN_THEME=dark   # force dark palette
+export QUIEN_THEME=auto   # auto-detect (default)
+```
+
 > [!TIP]
 > If you want `quien` to replace your default WHOIS tool, you can add an alias to your shell config:
 > ```sh

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -3,6 +3,7 @@ package display
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -38,15 +39,37 @@ func SetWidth(w int) {
 	displayWidth = w
 }
 
+func init() {
+	switch strings.ToLower(os.Getenv("QUIEN_THEME")) {
+	case "light":
+		lipgloss.SetHasDarkBackground(false)
+	case "dark":
+		lipgloss.SetHasDarkBackground(true)
+	}
+	// "auto" or unset: lipgloss detects automatically.
+}
+
+// ac returns an AdaptiveColor that picks light on light backgrounds and dark
+// on dark backgrounds. lipgloss detects the terminal background automatically.
+func ac(light, dark string) lipgloss.AdaptiveColor {
+	return lipgloss.AdaptiveColor{Light: light, Dark: dark}
+}
+
 var (
-	// Colors
-	cyan   = lipgloss.Color("#00D7FF")
-	green  = lipgloss.Color("#00FF87")
-	red    = lipgloss.Color("#FF5F87")
-	yellow = lipgloss.Color("#FFD700")
-	dim    = lipgloss.Color("#6C6C6C")
-	white  = lipgloss.Color("#FFFFFF")
-	faint  = lipgloss.Color("#4E4E4E")
+	// Colors — dark values are unchanged; light values target white/light backgrounds.
+	cyan   = ac("#0969DA", "#00D7FF")
+	green  = ac("#1A7F37", "#00FF87")
+	red    = ac("#CF222E", "#FF5F87")
+	yellow = ac("#9A6700", "#FFD700")
+	dim    = ac("#57606A", "#6C6C6C")
+	white  = ac("#1F2328", "#FFFFFF") // main body text
+	faint  = ac("#8C959F", "#4E4E4E")
+
+	// Secondary palette tokens used across multiple files.
+	accent  = ac("#2E59A1", "#87AFFF") // nameservers, headers, DNS records
+	muted   = ac("#57606A", "#A8A8A8") // TXT records, redirect URLs, mail records
+	border  = ac("#D0D7DE", "#3A3A3A") // box and panel borders
+	tabGray = ac("#57606A", "#A0A0A0") // inactive tab text
 
 	// Styles
 	domainStyle = lipgloss.NewStyle().
@@ -73,10 +96,10 @@ var (
 			Italic(true)
 
 	nsStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#87AFFF"))
+		Foreground(accent)
 
 	txtStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#A8A8A8"))
+			Foreground(muted)
 
 	dimStyle = lipgloss.NewStyle().
 			Foreground(dim)
@@ -88,7 +111,7 @@ var (
 func box() lipgloss.Style {
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#3A3A3A")).
+		BorderForeground(border).
 		Padding(1, boxPadH).
 		Width(displayWidth)
 }

--- a/internal/display/http.go
+++ b/internal/display/http.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	headerNameStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#87AFFF"))
+			Foreground(accent)
 
 	headerValStyle = lipgloss.NewStyle().
 			Foreground(white)
@@ -19,7 +19,7 @@ var (
 				Foreground(dim)
 
 	redirectURLStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#A8A8A8"))
+				Foreground(muted)
 
 	statusOKStyle = lipgloss.NewStyle().
 			Foreground(green).

--- a/internal/display/interactive.go
+++ b/internal/display/interactive.go
@@ -41,7 +41,7 @@ var (
 			PaddingLeft(2)
 
 	tabStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#A0A0A0")).
+			Foreground(tabGray).
 			PaddingRight(2)
 
 	tabKeyStyle = lipgloss.NewStyle().
@@ -63,8 +63,7 @@ var (
 			Foreground(dim).
 			PaddingLeft(2)
 
-	borderColor = lipgloss.Color("#3A3A3A")
-	borderFg    = lipgloss.NewStyle().Foreground(borderColor)
+	borderFg = lipgloss.NewStyle().Foreground(border)
 )
 
 // chrome = tab bar (1) + top border (1) + bottom border (1) + footer (1)

--- a/internal/display/mail.go
+++ b/internal/display/mail.go
@@ -11,7 +11,7 @@ import (
 var (
 	foundStyle    = lipgloss.NewStyle().Foreground(green)
 	notFoundStyle = lipgloss.NewStyle().Foreground(red)
-	recordStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#A8A8A8"))
+	recordStyle   = lipgloss.NewStyle().Foreground(muted)
 )
 
 // RenderMail returns a lipgloss-styled string for email-related DNS records.

--- a/internal/display/prompt.go
+++ b/internal/display/prompt.go
@@ -79,7 +79,7 @@ func (m PromptModel) View() string {
 		return ""
 	}
 
-	underline := lipgloss.NewStyle().Foreground(lipgloss.Color("#555555"))
+	underline := lipgloss.NewStyle().Foreground(ac("#AAAAAA", "#555555"))
 
 	var content strings.Builder
 	content.WriteString(promptTitleStyle.Render("quien"))
@@ -92,7 +92,7 @@ func (m PromptModel) View() string {
 
 	outerBox := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#3A3A3A")).
+		BorderForeground(border).
 		Padding(1, 3).
 		Width(50)
 

--- a/internal/display/stack.go
+++ b/internal/display/stack.go
@@ -9,18 +9,18 @@ import (
 
 var (
 	tagStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#000000")).
-			Background(lipgloss.Color("#87AFFF")).
+			Foreground(ac("#FFFFFF", "#000000")).
+			Background(accent).
 			Padding(0, 1)
 
 	tagGreenStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#000000")).
+			Foreground(ac("#FFFFFF", "#000000")).
 			Background(green).
 			Padding(0, 1)
 
 	tagDimStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#000000")).
-			Background(lipgloss.Color("#6C6C6C")).
+			Foreground(ac("#FFFFFF", "#000000")).
+			Background(dim).
 			Padding(0, 1)
 )
 


### PR DESCRIPTION

<img width="1826" height="1716" alt="Screenshot 2026-04-12 at 7 44 09 PM" src="https://github.com/user-attachments/assets/7b70566a-0c15-4742-9035-ae42af67d1b4" />

Closes #17

## Summary

- Switch all hardcoded `lipgloss.Color` values to `lipgloss.AdaptiveColor` so lipgloss automatically picks the right palette based on terminal background
- Dark theme is unchanged — same hex values as before
- Light theme uses GitHub Primer-derived colors for proven readability on white/light backgrounds
- Add `QUIEN_THEME` env var (`light`/`dark`/`auto`) to override auto-detection when terminals misreport their background (tmux, screen, remote shells)