### PR TITLE
Add MX resolution hotkey on Mail tab

### DIFF
--- a/internal/display/interactive.go
+++ b/internal/display/interactive.go
@@ -79,6 +79,9 @@ type Model struct {
 	whoisErr     error
 	dnsData      *dns.Records
 	mailData     *mail.Records
+	mxResolved   []mail.MXResolution
+	mxExpanded   bool
+	mxResolving  bool
 	tlsData      *tlsinfo.CertInfo
 	httpData     *httpinfo.Result
 	stackData    *stack.Result
@@ -121,6 +124,10 @@ type dnsResultMsg struct {
 type mailResultMsg struct {
 	records *mail.Records
 	err     error
+}
+
+type mxResolveMsg struct {
+	resolutions []mail.MXResolution
 }
 
 type tlsResultMsg struct {
@@ -262,6 +269,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.updateViewport()
 				return m, resolveFirstIP(m.domain)
 			}
+			if !m.isIP && m.active == tabMail && m.mailData != nil && len(m.mailData.MX) > 0 {
+				if m.mxResolved != nil {
+					m.mxExpanded = !m.mxExpanded
+					m.updateViewport()
+					return m, nil
+				}
+				if !m.mxResolving {
+					m.mxResolving = true
+					m.mxExpanded = true
+					m.updateViewport()
+					hosts := make([]string, len(m.mailData.MX))
+					for i, mx := range m.mailData.MX {
+						hosts[i] = mx.Host
+					}
+					return m, resolveMX(hosts)
+				}
+			}
 		default:
 			key := msg.String()
 			for _, t := range m.tabList() {
@@ -302,6 +326,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.ipInfo = msg.info
 		}
+		m.updateViewport()
+		return m, nil
+
+	case mxResolveMsg:
+		m.mxResolving = false
+		m.mxResolved = msg.resolutions
 		m.updateViewport()
 		return m, nil
 
@@ -495,7 +525,11 @@ func (m Model) contentForTab(t tab) string {
 		} else if m.mailErr != nil {
 			return errorBox("Mail Lookup Failed", m.mailErr)
 		} else if m.mailData != nil {
-			return RenderMail(m.mailData)
+			var res []mail.MXResolution
+			if m.mxExpanded {
+				res = m.mxResolved
+			}
+			return RenderMail(m.mailData, res)
 		}
 	case tabDNS:
 		if m.loading {
@@ -615,6 +649,15 @@ func (m Model) View() string {
 		footerParts = append(footerParts, "i failed")
 	} else if !m.isIP && m.active == tabWhois {
 		footerParts = append(footerParts, "i inspect ip")
+	} else if !m.isIP && m.active == tabMail && m.mailData != nil && len(m.mailData.MX) > 0 {
+		switch {
+		case m.mxResolving:
+			footerParts = append(footerParts, "i resolving...")
+		case m.mxExpanded:
+			footerParts = append(footerParts, "i collapse")
+		default:
+			footerParts = append(footerParts, "i resolve mx")
+		}
 	}
 	if m.isIP && m.prevDomain != "" {
 		footerParts = append(footerParts, "esc/w back")
@@ -737,6 +780,12 @@ func fetchWhois(domain string) tea.Cmd {
 	return func() tea.Msg {
 		info, err := resolver.Lookup(domain)
 		return whoisResultMsg{info: info, err: err}
+	}
+}
+
+func resolveMX(hosts []string) tea.Cmd {
+	return func() tea.Msg {
+		return mxResolveMsg{resolutions: mail.ResolveMX(hosts)}
 	}
 }
 

--- a/internal/display/mail.go
+++ b/internal/display/mail.go
@@ -15,11 +15,17 @@ var (
 )
 
 // RenderMail returns a lipgloss-styled string for email-related DNS records.
-func RenderMail(records *mail.Records) string {
+// mxResolutions (optional) adds expanded IP/rDNS info under each MX host.
+func RenderMail(records *mail.Records, mxResolutions []mail.MXResolution) string {
 	var b strings.Builder
 
 	b.WriteString(domainSectionTitle("Mail Configuration"))
 	b.WriteString("\n\n")
+
+	resolutionByHost := map[string]mail.MXResolution{}
+	for _, r := range mxResolutions {
+		resolutionByHost[r.Host] = r
+	}
 
 	// MX Records
 	b.WriteString(section("MX Records"))
@@ -27,6 +33,19 @@ func RenderMail(records *mail.Records) string {
 		for _, mx := range records.MX {
 			pri := dimStyle.Render(fmt.Sprintf("(%d)", mx.Priority))
 			b.WriteString(row("", nsStyle.Render(mx.Host)+" "+pri))
+			if res, ok := resolutionByHost[mx.Host]; ok {
+				if res.Err != "" {
+					b.WriteString(row("", dimStyle.Render("  "+notFoundStyle.Render(res.Err))))
+				} else {
+					for _, ip := range res.IPs {
+						line := recordStyle.Render("  " + ip.IP)
+						if ip.PTR != "" {
+							line += "  " + dimStyle.Render("("+ip.PTR+")")
+						}
+						b.WriteString(row("", line))
+					}
+				}
+			}
 		}
 	} else {
 		b.WriteString(row("", notFoundStyle.Render("No MX records found")))

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -1,10 +1,12 @@
 package mail
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	mdns "github.com/miekg/dns"
@@ -147,6 +149,57 @@ func Lookup(domain string) (*Records, error) {
 	}
 
 	return records, nil
+}
+
+// MXResolution pairs an MX host with its resolved IP addresses (and reverse DNS).
+type MXResolution struct {
+	Host string
+	IPs  []MXIP
+	Err  string
+}
+
+type MXIP struct {
+	IP  string
+	PTR string
+}
+
+// ResolveMX looks up A/AAAA records and reverse DNS for each MX host concurrently.
+func ResolveMX(hosts []string) []MXResolution {
+	out := make([]MXResolution, len(hosts))
+	var wg sync.WaitGroup
+	for i, h := range hosts {
+		wg.Add(1)
+		go func(i int, host string) {
+			defer wg.Done()
+			out[i].Host = host
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+			if err != nil {
+				out[i].Err = err.Error()
+				return
+			}
+			ips := make([]MXIP, len(addrs))
+			var inner sync.WaitGroup
+			for j, a := range addrs {
+				ips[j].IP = a.IP.String()
+				inner.Add(1)
+				go func(j int, ip string) {
+					defer inner.Done()
+					rctx, rcancel := context.WithTimeout(context.Background(), timeout)
+					defer rcancel()
+					names, err := net.DefaultResolver.LookupAddr(rctx, ip)
+					if err == nil && len(names) > 0 {
+						ips[j].PTR = strings.TrimSuffix(names[0], ".")
+					}
+				}(j, ips[j].IP)
+			}
+			inner.Wait()
+			out[i].IPs = ips
+		}(i, h)
+	}
+	wg.Wait()
+	return out
 }
 
 func query(name string, qtype uint16, resolver string) ([]mdns.RR, error) {


### PR DESCRIPTION
## Summary
- Adds `mail.ResolveMX`, which concurrently looks up A/AAAA and PTR records for a set of MX hosts
- Wires the `i` hotkey on the Mail tab to resolve + toggle an expanded view showing each MX host's IPs and rDNS, mirroring the existing `i inspect ip` affordance on the WHOIS tab
- Footer shows `i resolve mx` → `i resolving...` → `i collapse` as state progresses

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)