### PR TITLE
Add DNS resolver override

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ yay -S quien
 go install github.com/retlehs/quien@latest
 ```
 
+## Features
+
+- **RDAP-first lookups** with WHOIS fallback for broad TLD coverage
+- **IANA referral** for automatic WHOIS server discovery
+- **Mail configuration audit** — MX, SPF, DMARC, DKIM, and BIMI with VMC chain validation
+- **SEO analysis** — indexability (robots.txt, canonical, sitemap), on-page (title, description, headings, images), structured data (JSON-LD, Open Graph, Twitter Cards), and performance hints (compression, caching, render-blocking resources)
+- **Core Web Vitals** — LCP, INP, CLS, FCP, and TTFB field data with historical trends via the CrUX API (optional)
+- **Tech stack detection** including WordPress plugins, JS/CSS frameworks, and external services parsed from HTML
+- **IP lookups** with reverse DNS, network info, abuse contacts, and ASN discovery via RDAP
+- **BGP fallback** for origin ASN/prefix when RDAP does not include ASN data
+- **PeeringDB enrichment** for ASN context (network/org, peering policy, peering locations, traffic profile, IX/facility counts)
+- **Automatic retry** with exponential backoff on all lookups
+- **JSON subcommands** for scripting: `quien dns`, `quien mail`, `quien tls`, `quien http`, `quien seo`, `quien stack`, `quien all`
+
 ## Usage
 
 ```
@@ -47,21 +61,15 @@ quien 8.8.8.8
 
 # JSON output
 quien --json example.com
+
+# Use a specific DNS resolver for this run
+quien mail example.com --resolver 9.9.9.9
+
+# Set a default resolver via environment variable
+QUIEN_RESOLVER=1.1.1.1 quien dns example.com
 ```
 
-## Features
-
-- **RDAP-first lookups** with WHOIS fallback for broad TLD coverage
-- **IANA referral** for automatic WHOIS server discovery
-- **Mail configuration audit** — MX, SPF, DMARC, DKIM, and BIMI with VMC chain validation
-- **SEO analysis** — indexability (robots.txt, canonical, sitemap), on-page (title, description, headings, images), structured data (JSON-LD, Open Graph, Twitter Cards), and performance hints (compression, caching, render-blocking resources)
-- **Core Web Vitals** — LCP, INP, CLS, FCP, and TTFB field data with historical trends via the CrUX API (optional)
-- **Tech stack detection** including WordPress plugins, JS/CSS frameworks, and external services parsed from HTML
-- **IP lookups** with reverse DNS, network info, abuse contacts, and ASN discovery via RDAP
-- **BGP fallback** for origin ASN/prefix when RDAP does not include ASN data
-- **PeeringDB enrichment** for ASN context (network/org, peering policy, peering locations, traffic profile, IX/facility counts)
-- **Automatic retry** with exponential backoff on all lookups
-- **JSON subcommands** for scripting: `quien dns`, `quien mail`, `quien tls`, `quien http`, `quien seo`, `quien stack`, `quien all`
+Resolver precedence: `--resolver` > `QUIEN_RESOLVER` > system resolver.
 
 ## Core Web Vitals
 
@@ -97,6 +105,16 @@ quien automatically detects your terminal background and picks light or dark col
 export QUIEN_THEME=light  # force light palette
 export QUIEN_THEME=dark   # force dark palette
 export QUIEN_THEME=auto   # auto-detect (default)
+```
+
+## Troubleshooting DNS
+
+If your system resolver is unreliable (common in WSL, VPN, or container setups), force a resolver:
+
+```sh
+quien mail example.com --resolver 9.9.9.9
+# or
+export QUIEN_RESOLVER=9.9.9.9
 ```
 
 > [!TIP]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,12 +8,14 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/retlehs/quien/internal/display"
+	"github.com/retlehs/quien/internal/dnsutil"
 	"github.com/retlehs/quien/internal/resolver"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
 
 var jsonFlag bool
+var resolverFlag string
 
 var rootCmd = &cobra.Command{
 	Use:          "quien [domain or IP]",
@@ -21,6 +23,25 @@ var rootCmd = &cobra.Command{
 	Long:         "quien queries WHOIS/RDAP information for a domain or IP address and displays it in a clean, readable format.",
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if resolverFlag != "" {
+			normalized, err := dnsutil.NormalizeResolver(resolverFlag)
+			if err != nil {
+				return fmt.Errorf("invalid --resolver: %w", err)
+			}
+			return os.Setenv(dnsutil.ResolverEnvVar, normalized)
+		}
+
+		if envResolver := strings.TrimSpace(os.Getenv(dnsutil.ResolverEnvVar)); envResolver != "" {
+			normalized, err := dnsutil.NormalizeResolver(envResolver)
+			if err != nil {
+				return fmt.Errorf("invalid %s: %w", dnsutil.ResolverEnvVar, err)
+			}
+			return os.Setenv(dnsutil.ResolverEnvVar, normalized)
+		}
+
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// No args — show interactive prompt
 		if len(args) == 0 {
@@ -105,6 +126,7 @@ func runLookup(input string, isIP bool) error {
 
 func init() {
 	rootCmd.Flags().BoolVar(&jsonFlag, "json", false, "output as JSON")
+	rootCmd.PersistentFlags().StringVar(&resolverFlag, "resolver", "", "DNS resolver to use for DNS/mail lookups (host or host:port). Overrides "+dnsutil.ResolverEnvVar)
 }
 
 func Execute(version, commit, date string) {

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -2,12 +2,12 @@ package dns
 
 import (
 	"fmt"
-	"net"
 	"sort"
 	"strings"
 	"time"
 
 	mdns "github.com/miekg/dns"
+	"github.com/retlehs/quien/internal/dnsutil"
 )
 
 type Records struct {
@@ -190,13 +190,7 @@ func reverseLookup(ip string, resolver string) string {
 }
 
 func findResolver() string {
-	// Try to read system resolver
-	config, err := mdns.ClientConfigFromFile("/etc/resolv.conf")
-	if err == nil && len(config.Servers) > 0 {
-		return net.JoinHostPort(config.Servers[0], config.Port)
-	}
-	// Fallback to Cloudflare
-	return "1.1.1.1:53"
+	return dnsutil.FindResolver()
 }
 
 // decodeRNAME decodes a DNS SOA RNAME field to its original mailbox format.

--- a/internal/dnsutil/resolver.go
+++ b/internal/dnsutil/resolver.go
@@ -1,0 +1,71 @@
+package dnsutil
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	mdns "github.com/miekg/dns"
+)
+
+const ResolverEnvVar = "QUIEN_RESOLVER"
+
+// NormalizeResolver converts a resolver string into host:port form.
+// Accepted input forms are host, host:port, IPv4, IPv4:port, IPv6, [IPv6]:port.
+func NormalizeResolver(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", fmt.Errorf("resolver is empty")
+	}
+
+	if host, port, err := net.SplitHostPort(s); err == nil {
+		if host == "" {
+			return "", fmt.Errorf("resolver host is empty")
+		}
+		p, err := strconv.Atoi(port)
+		if err != nil || p < 1 || p > 65535 {
+			return "", fmt.Errorf("resolver port must be between 1 and 65535")
+		}
+		return net.JoinHostPort(host, strconv.Itoa(p)), nil
+	}
+
+	if strings.Count(s, ":") > 1 && net.ParseIP(s) == nil {
+		return "", fmt.Errorf("invalid resolver %q", s)
+	}
+
+	return net.JoinHostPort(s, "53"), nil
+}
+
+// ResolverFromEnv returns the normalized resolver from QUIEN_RESOLVER.
+// Empty string means not set or invalid.
+func ResolverFromEnv() string {
+	raw := strings.TrimSpace(os.Getenv(ResolverEnvVar))
+	if raw == "" {
+		return ""
+	}
+	resolver, err := NormalizeResolver(raw)
+	if err != nil {
+		return ""
+	}
+	return resolver
+}
+
+// FindResolver returns resolver from env override, /etc/resolv.conf, then fallback.
+func FindResolver() string {
+	if resolver := ResolverFromEnv(); resolver != "" {
+		return resolver
+	}
+
+	config, err := mdns.ClientConfigFromFile("/etc/resolv.conf")
+	if err == nil && len(config.Servers) > 0 {
+		port := config.Port
+		if p, pErr := strconv.Atoi(port); pErr != nil || p < 1 || p > 65535 {
+			port = "53"
+		}
+		return net.JoinHostPort(config.Servers[0], port)
+	}
+
+	return "1.1.1.1:53"
+}

--- a/internal/dnsutil/resolver_test.go
+++ b/internal/dnsutil/resolver_test.go
@@ -1,0 +1,34 @@
+package dnsutil
+
+import "testing"
+
+func TestNormalizeResolver(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "9.9.9.9", want: "9.9.9.9:53"},
+		{in: "9.9.9.9:5353", want: "9.9.9.9:5353"},
+		{in: "2001:4860:4860::8888", want: "[2001:4860:4860::8888]:53"},
+		{in: "[2001:4860:4860::8888]:5353", want: "[2001:4860:4860::8888]:5353"},
+		{in: "example.com", want: "example.com:53"},
+		{in: "1.1.1.1:70000", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		got, err := NormalizeResolver(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("NormalizeResolver(%q) expected error, got %q", tt.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("NormalizeResolver(%q) unexpected error: %v", tt.in, err)
+		}
+		if got != tt.want {
+			t.Fatalf("NormalizeResolver(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	mdns "github.com/miekg/dns"
+	"github.com/retlehs/quien/internal/dnsutil"
 )
 
 type Records struct {
@@ -227,9 +228,5 @@ func query(name string, qtype uint16, resolver string) ([]mdns.RR, error) {
 }
 
 func findResolver() string {
-	config, err := mdns.ClientConfigFromFile("/etc/resolv.conf")
-	if err == nil && len(config.Servers) > 0 {
-		return net.JoinHostPort(config.Servers[0], config.Port)
-	}
-	return "1.1.1.1:53"
+	return dnsutil.FindResolver()
 }


### PR DESCRIPTION
- Add a DNS resolver override via `--resolver`
- Add `QUIEN_RESOLVER` environment variable support
- Route DNS and mail resolver selection through shared resolver utility
- Apply precedence: `--resolver` > `QUIEN_RESOLVER` > system resolver

Some environments (for example WSL/VPN/container DNS paths) can return inconsistent results through the default system resolver. This adds an explicit override path for reliable lookups and easier troubleshooting.

Ref #20