### PR TITLE
Add `whois` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ go install github.com/retlehs/quien@latest
 - **BGP fallback** for origin ASN/prefix when RDAP does not include ASN data
 - **PeeringDB enrichment** for ASN context (network/org, peering policy, peering locations, traffic profile, IX/facility counts)
 - **Automatic retry** with exponential backoff on all lookups
-- **JSON subcommands** for scripting: `quien dns`, `quien mail`, `quien tls`, `quien http`, `quien seo`, `quien stack`, `quien all`
+- **JSON subcommands** for scripting: `quien whois`, `quien dns`, `quien mail`, `quien tls`, `quien http`, `quien seo`, `quien stack`, `quien all`
 
 ## Usage
 
@@ -61,6 +61,16 @@ quien 8.8.8.8
 
 # JSON output
 quien --json example.com
+
+# Commands
+quien whois example.com
+quien dns example.com
+quien mail example.com
+quien tls example.com
+quien http example.com
+quien stack example.com
+quien seo example.com
+quien all example.com
 
 # Use a specific DNS resolver for this run
 quien mail example.com --resolver 9.9.9.9

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ quien 8.8.8.8
 # JSON output
 quien --json example.com
 
-# Commands
+# JSON subcommands
 quien whois example.com
 quien dns example.com
 quien mail example.com

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ When the user asks questions about domains or IP addresses, use `quien` instead 
 
 ```bash
 # WHOIS / domain registration
-quien --json example.com
+quien whois example.com
 
 # DNS records (A, AAAA, CNAME, MX, NS, TXT, PTR, SOA, DNSSEC)
 quien dns example.com
@@ -28,11 +28,14 @@ quien http example.com
 # Tech stack detection (CMS, frameworks, JS/CSS libraries, plugins)
 quien stack example.com
 
+# SEO analysis (indexability, on-page, structured data, Core Web Vitals)
+quien seo example.com
+
 # Everything at once
 quien all example.com
 
 # IP address lookup
-quien --json 8.8.8.8
+quien whois 8.8.8.8
 
 ```
 
@@ -42,14 +45,15 @@ All subcommands output JSON. Use `quien all` when you need a complete picture.
 
 | User asks about | Command |
 |---|---|
-| Domain owner, registrar, expiry | `quien --json example.com` |
+| Domain owner, registrar, expiry | `quien whois example.com` |
 | DNS records | `quien dns example.com` |
 | Email setup, SPF, DMARC, DKIM | `quien mail example.com` |
 | SSL certificate, expiry | `quien tls example.com` |
 | HTTP headers, redirects, server | `quien http example.com` |
 | Tech stack, CMS, framework | `quien stack example.com` |
+| SEO, Core Web Vitals | `quien seo example.com` |
 | Everything about a domain | `quien all example.com` |
-| IP owner, network, abuse contact | `quien --json 8.8.8.8` |
+| IP owner, network, abuse contact | `quien whois 8.8.8.8` |
 
 ## Install
 

--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -9,9 +9,10 @@ import (
 )
 
 var tlsCmd = &cobra.Command{
-	Use:   "tls <domain>",
-	Short: "SSL/TLS certificate lookup (JSON output)",
-	Args:  cobra.ExactArgs(1),
+	Use:     "tls <domain>",
+	Aliases: []string{"ssl"},
+	Short:   "SSL/TLS certificate lookup (JSON output)",
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		domain := normalizeDomain(args[0])
 		cert, err := retry.Do(func() (*tlsinfo.CertInfo, error) {

--- a/cmd/whois.go
+++ b/cmd/whois.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/retlehs/quien/internal/resolver"
+	"github.com/spf13/cobra"
+)
+
+var whoisCmd = &cobra.Command{
+	Use:   "whois <domain or IP>",
+	Short: "WHOIS/RDAP registration lookup (JSON output)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		input := normalizeDomain(args[0])
+		if net.ParseIP(input) != nil {
+			info, err := resolver.LookupIP(input)
+			if err != nil {
+				return fmt.Errorf("IP lookup failed: %w", err)
+			}
+			return printJSON(info)
+		}
+		info, err := resolver.Lookup(input)
+		if err != nil {
+			return fmt.Errorf("WHOIS lookup failed: %w", err)
+		}
+		return printJSON(info)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(whoisCmd)
+}


### PR DESCRIPTION
## Summary
- Add `quien whois <domain|IP>` subcommand for JSON WHOIS/RDAP output, filling the gap alongside the existing `dns`/`mail`/`tls`/`http`/`stack`/`seo`/`all` subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)