### PR TITLE
Route IP jump through configured resolver

### DIFF
--- a/internal/display/interactive.go
+++ b/internal/display/interactive.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/retlehs/quien/internal/dns"
+	"github.com/retlehs/quien/internal/dnsutil"
 	"github.com/retlehs/quien/internal/httpinfo"
 	"github.com/retlehs/quien/internal/mail"
 	"github.com/retlehs/quien/internal/model"
@@ -267,7 +268,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.resolvingIP = true
 				m.loading = true
 				m.updateViewport()
-				return m, resolveFirstIP(m.domain)
+				return m, resolveFirstIP(m.domain, m.dnsData)
 			}
 			if !m.isIP && m.active == tabMail && m.mailData != nil && len(m.mailData.MX) > 0 {
 				if m.mxResolved != nil {
@@ -737,25 +738,74 @@ func fetchIP(ip string) tea.Cmd {
 	}
 }
 
-func resolveFirstIP(domain string) tea.Cmd {
+func resolveFirstIP(domain string, cached *dns.Records) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		ips, err := net.DefaultResolver.LookupIPAddr(ctx, domain)
+		ip, err := resolveFirstIPValue(domain, cached, ipLookupDeps{
+			lookupDNSIPs: dns.LookupIPAddrs,
+			lookupIPAddr: lookupIPAddrViaConfiguredResolver,
+		})
 		if err != nil {
 			return resolveIPResultMsg{err: err}
 		}
-		if len(ips) == 0 {
-			return resolveIPResultMsg{err: fmt.Errorf("no IP found for %s", domain)}
-		}
-
-		for _, ip := range ips {
-			if v4 := ip.IP.To4(); v4 != nil {
-				return resolveIPResultMsg{ip: v4.String()}
-			}
-		}
-		return resolveIPResultMsg{ip: ips[0].IP.String()}
+		return resolveIPResultMsg{ip: ip}
 	}
+}
+
+type ipLookupDeps struct {
+	lookupDNSIPs func(domain string) ([]string, []string, error)
+	lookupIPAddr func(ctx context.Context, domain string) ([]net.IPAddr, error)
+}
+
+func resolveFirstIPValue(domain string, cached *dns.Records, deps ipLookupDeps) (string, error) {
+	if ip := firstIPFromDNSRecords(cached); ip != "" {
+		return ip, nil
+	}
+
+	a, aaaa, err := deps.lookupDNSIPs(domain)
+	if err == nil {
+		if ip := firstIPFromSlices(a, aaaa); ip != "" {
+			return ip, nil
+		}
+		return "", fmt.Errorf("no IP found for %s", domain)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ips, err := deps.lookupIPAddr(ctx, domain)
+	if err != nil {
+		return "", err
+	}
+	if len(ips) == 0 {
+		return "", fmt.Errorf("no IP found for %s", domain)
+	}
+
+	for _, ip := range ips {
+		if v4 := ip.IP.To4(); v4 != nil {
+			return v4.String(), nil
+		}
+	}
+	return ips[0].IP.String(), nil
+}
+
+func firstIPFromDNSRecords(records *dns.Records) string {
+	if records == nil {
+		return ""
+	}
+	return firstIPFromSlices(records.A, records.AAAA)
+}
+
+func firstIPFromSlices(a []string, aaaa []string) string {
+	if len(a) > 0 && a[0] != "" {
+		return a[0]
+	}
+	if len(aaaa) > 0 && aaaa[0] != "" {
+		return aaaa[0]
+	}
+	return ""
+}
+
+func lookupIPAddrViaConfiguredResolver(ctx context.Context, domain string) ([]net.IPAddr, error) {
+	return dnsutil.GoResolver(5*time.Second).LookupIPAddr(ctx, domain)
 }
 
 func (m Model) viewportSize() (int, int) {

--- a/internal/display/interactive_test.go
+++ b/internal/display/interactive_test.go
@@ -1,0 +1,118 @@
+package display
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/retlehs/quien/internal/dns"
+)
+
+func TestResolveFirstIPValuePrefersCachedDNSRecords(t *testing.T) {
+	t.Parallel()
+
+	ip, err := resolveFirstIPValue("example.com", &dns.Records{
+		A: []string{"93.184.216.34"},
+	}, ipLookupDeps{
+		lookupDNSIPs: func(domain string) ([]string, []string, error) {
+			return []string{"127.0.1.1"}, nil, nil
+		},
+		lookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("127.0.1.1")}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveFirstIPValue() error = %v", err)
+	}
+	if ip != "93.184.216.34" {
+		t.Fatalf("resolveFirstIPValue() = %q, want %q", ip, "93.184.216.34")
+	}
+}
+
+func TestResolveFirstIPValueUsesCachedAAAAWhenAIsMissing(t *testing.T) {
+	t.Parallel()
+
+	ip, err := resolveFirstIPValue("example.com", &dns.Records{
+		AAAA: []string{"2001:db8::44"},
+	}, ipLookupDeps{
+		lookupDNSIPs: func(domain string) ([]string, []string, error) {
+			return []string{"198.51.100.11"}, nil, nil
+		},
+		lookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("127.0.1.1")}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveFirstIPValue() error = %v", err)
+	}
+	if ip != "2001:db8::44" {
+		t.Fatalf("resolveFirstIPValue() = %q, want %q", ip, "2001:db8::44")
+	}
+}
+
+func TestResolveFirstIPValueCachedEmptyUsesDNSLookup(t *testing.T) {
+	t.Parallel()
+
+	lookupDNSCalled := false
+	ip, err := resolveFirstIPValue("example.com", &dns.Records{}, ipLookupDeps{
+		lookupDNSIPs: func(domain string) ([]string, []string, error) {
+			lookupDNSCalled = true
+			return []string{"198.51.100.22"}, nil, nil
+		},
+		lookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+			t.Fatalf("unexpected fallback lookup call")
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveFirstIPValue() error = %v", err)
+	}
+	if !lookupDNSCalled {
+		t.Fatalf("expected DNS lookup to be called")
+	}
+	if ip != "198.51.100.22" {
+		t.Fatalf("resolveFirstIPValue() = %q, want %q", ip, "198.51.100.22")
+	}
+}
+
+func TestResolveFirstIPValueFallsBackToConfiguredResolver(t *testing.T) {
+	t.Parallel()
+
+	ip, err := resolveFirstIPValue("example.com", nil, ipLookupDeps{
+		lookupDNSIPs: func(domain string) ([]string, []string, error) {
+			return nil, nil, fmt.Errorf("dns failed")
+		},
+		lookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+			return []net.IPAddr{
+				{IP: net.ParseIP("2001:db8::1")},
+				{IP: net.ParseIP("198.51.100.7")},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveFirstIPValue() error = %v", err)
+	}
+	if ip != "198.51.100.7" {
+		t.Fatalf("resolveFirstIPValue() = %q, want %q", ip, "198.51.100.7")
+	}
+}
+
+func TestResolveFirstIPValueUsesAAAAWhenANotPresent(t *testing.T) {
+	t.Parallel()
+
+	ip, err := resolveFirstIPValue("example.com", nil, ipLookupDeps{
+		lookupDNSIPs: func(domain string) ([]string, []string, error) {
+			return nil, []string{"2001:db8::2"}, nil
+		},
+		lookupIPAddr: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("127.0.1.1")}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveFirstIPValue() error = %v", err)
+	}
+	if ip != "2001:db8::2" {
+		t.Fatalf("resolveFirstIPValue() = %q, want %q", ip, "2001:db8::2")
+	}
+}

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -44,6 +44,38 @@ type SOARecord struct {
 
 const timeout = 5 * time.Second
 
+// LookupIPAddrs queries only A and AAAA records for the given domain.
+func LookupIPAddrs(domain string) (a []string, aaaa []string, err error) {
+	if !strings.HasSuffix(domain, ".") {
+		domain = domain + "."
+	}
+
+	resolver := findResolver()
+	aRR, aErr := query(domain, mdns.TypeA, resolver)
+	if aErr == nil {
+		for _, r := range aRR {
+			if rec, ok := r.(*mdns.A); ok {
+				a = append(a, rec.A.String())
+			}
+		}
+	}
+
+	aaaaRR, aaaaErr := query(domain, mdns.TypeAAAA, resolver)
+	if aaaaErr == nil {
+		for _, r := range aaaaRR {
+			if rec, ok := r.(*mdns.AAAA); ok {
+				aaaa = append(aaaa, rec.AAAA.String())
+			}
+		}
+	}
+
+	if aErr != nil && aaaaErr != nil {
+		return nil, nil, fmt.Errorf("a lookup failed: %v; aaaa lookup failed: %v", aErr, aaaaErr)
+	}
+
+	return a, aaaa, nil
+}
+
 // Lookup queries common DNS record types for the given domain.
 func Lookup(domain string) (*Records, error) {
 	// Ensure domain has trailing dot for DNS queries

--- a/internal/dnsutil/resolver.go
+++ b/internal/dnsutil/resolver.go
@@ -54,22 +54,49 @@ func ResolverFromEnv() string {
 	return resolver
 }
 
-// FindResolver returns resolver from env override, /etc/resolv.conf, then fallback.
+// resolvConfPaths are probed in order. systemd-resolved's stub at 127.0.0.53
+// consults /etc/hosts, so prefer the file with the real upstream DNS servers
+// when it exists.
+var resolvConfPaths = []string{
+	"/run/systemd/resolve/resolv.conf",
+	"/etc/resolv.conf",
+}
+
+// FindResolver returns resolver from env override, resolv.conf, then fallback.
 func FindResolver() string {
 	if resolver := ResolverFromEnv(); resolver != "" {
 		return resolver
 	}
+	if resolver := resolverFromFiles(resolvConfPaths); resolver != "" {
+		return resolver
+	}
+	return "1.1.1.1:53"
+}
 
-	config, err := mdns.ClientConfigFromFile("/etc/resolv.conf")
-	if err == nil && len(config.Servers) > 0 {
+// resolverFromFiles returns the first non-loopback nameserver found across the
+// given resolv.conf-style files. Loopback nameservers are skipped because
+// they're typically stub resolvers (e.g. systemd-resolved) that honor
+// /etc/hosts, which defeats the purpose of querying authoritative DNS for a
+// public domain.
+func resolverFromFiles(paths []string) string {
+	for _, path := range paths {
+		config, err := mdns.ClientConfigFromFile(path)
+		if err != nil {
+			continue
+		}
 		port := config.Port
 		if p, pErr := strconv.Atoi(port); pErr != nil || p < 1 || p > 65535 {
 			port = "53"
 		}
-		return net.JoinHostPort(config.Servers[0], port)
+		for _, server := range config.Servers {
+			ip := net.ParseIP(server)
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			return net.JoinHostPort(server, port)
+		}
 	}
-
-	return "1.1.1.1:53"
+	return ""
 }
 
 // GoResolver returns a net.Resolver that bypasses local NSS/files and dials the

--- a/internal/dnsutil/resolver.go
+++ b/internal/dnsutil/resolver.go
@@ -1,11 +1,13 @@
 package dnsutil
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	mdns "github.com/miekg/dns"
 )
@@ -68,4 +70,20 @@ func FindResolver() string {
 	}
 
 	return "1.1.1.1:53"
+}
+
+// GoResolver returns a net.Resolver that bypasses local NSS/files and dials the
+// configured DNS server directly.
+func GoResolver(timeout time.Duration) *net.Resolver {
+	target := FindResolver()
+	dialer := &net.Dialer{Timeout: timeout}
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			if strings.HasPrefix(network, "tcp") {
+				return dialer.DialContext(ctx, "tcp", target)
+			}
+			return dialer.DialContext(ctx, "udp", target)
+		},
+	}
 }

--- a/internal/dnsutil/resolver_test.go
+++ b/internal/dnsutil/resolver_test.go
@@ -1,6 +1,10 @@
 package dnsutil
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestNormalizeResolver(t *testing.T) {
 	tests := []struct {
@@ -30,5 +34,48 @@ func TestNormalizeResolver(t *testing.T) {
 		if got != tt.want {
 			t.Fatalf("NormalizeResolver(%q) = %q, want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+func TestResolverFromFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	stub := filepath.Join(dir, "stub-resolv.conf")
+	if err := os.WriteFile(stub, []byte("nameserver 127.0.0.53\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	upstream := filepath.Join(dir, "resolv.conf")
+	if err := os.WriteFile(upstream, []byte("nameserver 1.1.1.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mixed := filepath.Join(dir, "mixed-resolv.conf")
+	if err := os.WriteFile(mixed, []byte("nameserver 127.0.0.1\nnameserver 8.8.8.8\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	missing := filepath.Join(dir, "does-not-exist.conf")
+
+	tests := []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{name: "prefers first non-loopback file", paths: []string{upstream, stub}, want: "1.1.1.1:53"},
+		{name: "skips loopback-only file", paths: []string{stub, upstream}, want: "1.1.1.1:53"},
+		{name: "skips missing file", paths: []string{missing, upstream}, want: "1.1.1.1:53"},
+		{name: "skips loopback server within file", paths: []string{mixed}, want: "8.8.8.8:53"},
+		{name: "returns empty when all loopback", paths: []string{stub}, want: ""},
+		{name: "returns empty when no files readable", paths: []string{missing}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolverFromFiles(tt.paths)
+			if got != tt.want {
+				t.Fatalf("resolverFromFiles(%v) = %q, want %q", tt.paths, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -205,17 +205,7 @@ func ResolveMX(hosts []string) []MXResolution {
 }
 
 func resolverForMX() *net.Resolver {
-	target := findResolver()
-	dialer := &net.Dialer{Timeout: timeout}
-	return &net.Resolver{
-		PreferGo: true,
-		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
-			if strings.HasPrefix(network, "tcp") {
-				return dialer.DialContext(ctx, "tcp", target)
-			}
-			return dialer.DialContext(ctx, "udp", target)
-		},
-	}
+	return dnsutil.GoResolver(timeout)
 }
 
 func query(name string, qtype uint16, resolver string) ([]mdns.RR, error) {


### PR DESCRIPTION
Fixes #26

On Debian/Ubuntu, `/etc/hosts` commonly maps the FQDN to `127.0.1.1`. The IP lookup resolved to that loopback and RDAP failed with `no RDAP server found for 127.0.1.1`. Two root causes:

1. The IP jump used `net.DefaultResolver`, which honors `/etc/hosts` / NSS
2. Auto-detected resolvers on systemd-resolved systems point at the `127.0.0.53` stub, which itself consults `/etc/hosts` — so routing through the "configured resolver" still returned the local override

## Changes

- Prefer cached A/AAAA from the DNS tab when available
- Add `dns.LookupIPAddrs` for narrow A/AAAA-only lookup via configured resolver
- Fall back to `dnsutil.GoResolver` only when `LookupIPAddrs` errors
- Refactor `mail.resolverForMX` to use `dnsutil.GoResolver`
- `dnsutil.FindResolver` prefers `/run/systemd/resolve/resolv.conf` and skips loopback nameservers, falling through to `1.1.1.1:53`. Explicit `--resolver` / `QUIEN_RESOLVER` overrides are unchanged

## Test plan

- [x] On Ubuntu with `127.0.1.1 <fqdn>` in `/etc/hosts`, run `quien <fqdn>` and check the IP lookup, it should use public address, not loopback