### PR TITLE
Add SPF lookup analysis and tree expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ go install github.com/retlehs/quien@latest
 - **IP lookups** with reverse DNS, network info, abuse contacts, and ASN discovery via RDAP
   - **BGP fallback** for origin ASN/prefix when RDAP does not include ASN data
   - **PeeringDB enrichment** for ASN context (network/org, peering policy, peering locations, traffic profile, IX/facility counts)
-- **Mail configuration audit** — MX, SPF, DMARC, DKIM, and BIMI with VMC chain validation
+- **Mail configuration audit** — MX, SPF (with lookup-count and include/redirect tree expansion), DMARC, DKIM, and BIMI with VMC chain validation
 - **SEO analysis** — indexability (robots.txt, canonical, sitemap), on-page (title, description, headings, images), structured data (JSON-LD, Open Graph, Twitter Cards), and performance hints (compression, caching, render-blocking resources)
   - **Core Web Vitals** — LCP, INP, CLS, FCP, and TTFB field data with historical trends via the CrUX API (optional)
 - **Tech stack detection** including WordPress plugins, JS/CSS frameworks, and external services parsed from HTML

--- a/internal/display/interactive.go
+++ b/internal/display/interactive.go
@@ -83,6 +83,8 @@ type Model struct {
 	mxResolved   []mail.MXResolution
 	mxExpanded   bool
 	mxResolving  bool
+	spfDepth     int  // 0 = top-level only, N = N layers, SPFExpandAll = full
+	spfExpanded  bool // any layer expanded yet
 	tlsData      *tlsinfo.CertInfo
 	httpData     *httpinfo.Result
 	stackData    *stack.Result
@@ -291,6 +293,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 					return m, resolveMX(hosts)
 				}
+			}
+		case "x":
+			if !m.isIP && m.active == tabMail && m.mailHasSPFTree() {
+				max := spfMaxDepth(m.spfRoot())
+				switch {
+				case m.spfDepth == SPFExpandAll || m.spfDepth >= max:
+					m.spfDepth = 0
+					m.spfExpanded = false
+				default:
+					m.spfDepth++
+					m.spfExpanded = true
+				}
+				m.updateViewport()
+				return m, nil
+			}
+		case "X":
+			if !m.isIP && m.active == tabMail && m.mailHasSPFTree() {
+				max := spfMaxDepth(m.spfRoot())
+				if m.spfDepth == SPFExpandAll || m.spfDepth >= max {
+					m.spfDepth = 0
+					m.spfExpanded = false
+				} else {
+					m.spfDepth = SPFExpandAll
+					m.spfExpanded = true
+				}
+				m.updateViewport()
+				return m, nil
 			}
 		default:
 			key := msg.String()
@@ -535,7 +564,7 @@ func (m Model) contentForTab(t tab) string {
 			if m.mxExpanded {
 				res = m.mxResolved
 			}
-			return RenderMail(m.mailData, res)
+			return RenderMail(m.mailData, res, m.spfDepth)
 		}
 	case tabDNS:
 		if m.loading {
@@ -664,6 +693,17 @@ func (m Model) View() tea.View {
 			footerParts = append(footerParts, "i collapse")
 		default:
 			footerParts = append(footerParts, "i resolve mx")
+		}
+	}
+	if !m.isIP && m.active == tabMail && m.mailHasSPFTree() {
+		max := spfMaxDepth(m.spfRoot())
+		switch {
+		case m.spfDepth == SPFExpandAll || m.spfDepth >= max:
+			footerParts = append(footerParts, "x/X collapse spf")
+		case m.spfExpanded:
+			footerParts = append(footerParts, "x more  X all")
+		default:
+			footerParts = append(footerParts, "x/X expand spf")
 		}
 	}
 	if m.isIP && m.prevDomain != "" {
@@ -818,6 +858,41 @@ func firstIPFromSlices(a []string, aaaa []string) string {
 
 func lookupIPAddrViaConfiguredResolver(ctx context.Context, domain string) ([]net.IPAddr, error) {
 	return dnsutil.GoResolver(5*time.Second).LookupIPAddr(ctx, domain)
+}
+
+// mailHasSPFTree reports whether the SPF analysis has a tree worth expanding —
+// i.e. at least one include or redirect at the root.
+func (m Model) mailHasSPFTree() bool {
+	return spfMaxDepth(m.spfRoot()) > 0
+}
+
+func (m Model) spfRoot() *mail.SPFNode {
+	if m.mailData == nil || m.mailData.SPFAnalysis == nil {
+		return nil
+	}
+	return m.mailData.SPFAnalysis.Root
+}
+
+// spfMaxDepth returns the deepest level of include/redirect nesting that has
+// children worth showing. 0 means no expansion possible.
+func spfMaxDepth(node *mail.SPFNode) int {
+	if node == nil {
+		return 0
+	}
+	max := 0
+	for _, c := range node.Children {
+		if c.Mechanism != "include" && c.Mechanism != "redirect" {
+			continue
+		}
+		if len(c.Children) == 0 {
+			continue
+		}
+		d := 1 + spfMaxDepth(c)
+		if d > max {
+			max = d
+		}
+	}
+	return max
 }
 
 func (m Model) viewportSize() (int, int) {

--- a/internal/display/mail.go
+++ b/internal/display/mail.go
@@ -14,9 +14,14 @@ var (
 	recordStyle   = lipgloss.NewStyle().Foreground(muted)
 )
 
+// SPFExpandAll signals "expand every layer" to RenderMail.
+const SPFExpandAll = -1
+
 // RenderMail returns a lipgloss-styled string for email-related DNS records.
 // mxResolutions (optional) adds expanded IP/rDNS info under each MX host.
-func RenderMail(records *mail.Records, mxResolutions []mail.MXResolution) string {
+// spfDepth controls how many layers of include/redirect to render in the SPF
+// tree: 0 = top-level terms only, N = N nested layers, SPFExpandAll = full.
+func RenderMail(records *mail.Records, mxResolutions []mail.MXResolution, spfDepth int) string {
 	var b strings.Builder
 
 	b.WriteString(domainSectionTitle("Mail Configuration"))
@@ -54,13 +59,7 @@ func RenderMail(records *mail.Records, mxResolutions []mail.MXResolution) string
 	// SPF
 	b.WriteString("\n")
 	b.WriteString(section("SPF"))
-	if records.SPF != "" {
-		b.WriteString(row("Status", foundStyle.Render("found")))
-		// Word-wrap long SPF records
-		b.WriteString(wrapRecord(records.SPF))
-	} else {
-		b.WriteString(row("Status", notFoundStyle.Render("not found")))
-	}
+	renderSPF(&b, records.SPF, records.SPFAnalysis, spfDepth)
 
 	// DMARC
 	b.WriteString("\n")
@@ -133,6 +132,127 @@ func renderVMC(b *strings.Builder, vmc *mail.VMCInfo) {
 	if vmc.Issuer != "" {
 		b.WriteString(row("Issuer", vmc.Issuer))
 	}
+}
+
+var (
+	spfOkStyle    = lipgloss.NewStyle().Foreground(green)
+	spfWarnStyle  = lipgloss.NewStyle().Foreground(yellow)
+	spfErrorStyle = lipgloss.NewStyle().Foreground(red)
+)
+
+func renderSPF(b *strings.Builder, raw string, a *mail.SPFAnalysis, depth int) {
+	if raw == "" && (a == nil || len(a.Records) == 0) {
+		b.WriteString(row("Status", notFoundStyle.Render("not found")))
+		if a != nil {
+			for _, e := range a.Errors {
+				b.WriteString(row("Error", notFoundStyle.Render(e)))
+			}
+		}
+		return
+	}
+
+	b.WriteString(row("Status", foundStyle.Render("found")))
+
+	if a != nil {
+		b.WriteString(row("Lookups", spfLookupBadge(a)))
+		if a.VoidCount > 0 {
+			b.WriteString(row("Inc voids", spfVoidBadge(a)))
+		}
+		if a.Multiple {
+			b.WriteString(row("Warning", notFoundStyle.Render(fmt.Sprintf("multiple SPF records (%d) — PermError", len(a.Records)))))
+		}
+		for _, e := range a.Errors {
+			b.WriteString(row("Error", notFoundStyle.Render(e)))
+		}
+	}
+
+	if raw != "" {
+		b.WriteString(wrapRecord(raw))
+	}
+
+	if a != nil && a.Root != nil {
+		renderSPFTree(b, a.Root, 0, depth)
+	}
+}
+
+func spfLookupBadge(a *mail.SPFAnalysis) string {
+	text := fmt.Sprintf("%d / %d", a.LookupCount, a.LookupLimit)
+	switch {
+	case a.OverLimit:
+		return spfErrorStyle.Render(text + "  PermError")
+	case a.LookupCount >= 8:
+		return spfWarnStyle.Render(text)
+	default:
+		return spfOkStyle.Render(text)
+	}
+}
+
+func spfVoidBadge(a *mail.SPFAnalysis) string {
+	text := fmt.Sprintf("%d / %d", a.VoidCount, a.VoidLimit)
+	if a.OverVoidLimit {
+		return spfErrorStyle.Render(text + "  over limit")
+	}
+	return spfWarnStyle.Render(text)
+}
+
+// renderSPFTree writes the children of node, indented by depth. maxDepth
+// caps how many levels of include/redirect to descend into.
+// SPFExpandAll (-1) means unlimited.
+func renderSPFTree(b *strings.Builder, node *mail.SPFNode, depth int, maxDepth int) {
+	if node == nil {
+		return
+	}
+	for _, child := range node.Children {
+		writeSPFNode(b, child, depth)
+		if (child.Mechanism == "include" || child.Mechanism == "redirect") &&
+			len(child.Children) > 0 &&
+			(maxDepth == SPFExpandAll || depth < maxDepth) {
+			renderSPFTree(b, child, depth+1, maxDepth)
+		}
+	}
+}
+
+func writeSPFNode(b *strings.Builder, n *mail.SPFNode, depth int) {
+	indent := strings.Repeat("  ", depth+1)
+	prefix := indent + dimStyle.Render("→ ")
+
+	term := n.Qualifier + n.Mechanism
+	if n.Target != "" {
+		switch {
+		case strings.HasPrefix(n.Target, "/"):
+			term += n.Target
+		case n.Mechanism == "redirect" || n.Mechanism == "exp":
+			term = n.Mechanism + "=" + n.Target
+		default:
+			term += ":" + n.Target
+		}
+	}
+
+	var styled string
+	switch {
+	case n.CountsLookup:
+		styled = nsStyle.Render(term)
+	default:
+		styled = recordStyle.Render(term)
+	}
+
+	annotations := []string{}
+	switch {
+	case n.Ignored:
+		annotations = append(annotations, dimStyle.Render("ignored — after all"))
+	case n.Error != "":
+		annotations = append(annotations, spfErrorStyle.Render("error: "+n.Error))
+	case n.Void:
+		annotations = append(annotations, spfWarnStyle.Render("void — no SPF record"))
+	case n.Unresolved:
+		annotations = append(annotations, dimStyle.Render("macro — not resolved"))
+	}
+
+	line := prefix + styled
+	if len(annotations) > 0 {
+		line += "  " + dimStyle.Render("(") + strings.Join(annotations, dimStyle.Render(", ")) + dimStyle.Render(")")
+	}
+	b.WriteString(row("", line))
 }
 
 func wrapRecord(s string) string {

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -14,11 +14,12 @@ import (
 )
 
 type Records struct {
-	MX    []MXRecord
-	SPF   string
-	DMARC string
-	DKIM  []DKIMRecord
-	BIMI  *BIMIRecord `json:",omitempty"`
+	MX          []MXRecord
+	SPF         string
+	SPFAnalysis *SPFAnalysis `json:",omitempty"`
+	DMARC       string
+	DKIM        []DKIMRecord
+	BIMI        *BIMIRecord `json:",omitempty"`
 }
 
 type MXRecord struct {
@@ -89,17 +90,14 @@ func Lookup(domain string) (*Records, error) {
 		})
 	}
 
-	// SPF — look for "v=spf1" in TXT records
-	if rr, err := query(domain+".", mdns.TypeTXT, resolver); err == nil {
-		for _, r := range rr {
-			if txt, ok := r.(*mdns.TXT); ok {
-				val := strings.Join(txt.Txt, "")
-				if strings.HasPrefix(strings.ToLower(val), "v=spf1") {
-					records.SPF = val
-					break
-				}
-			}
-		}
+	// SPF — analyze and walk include/redirect chain. AnalyzeSPF collects all
+	// v=spf1 records at the root so multi-record (PermError) is detected.
+	analysis := AnalyzeSPF(domain, nil)
+	if len(analysis.Records) > 0 {
+		records.SPF = analysis.Records[0]
+		records.SPFAnalysis = analysis
+	} else if len(analysis.Errors) > 0 {
+		records.SPFAnalysis = analysis
 	}
 
 	// DMARC — TXT record at _dmarc.<domain>

--- a/internal/mail/spf.go
+++ b/internal/mail/spf.go
@@ -1,0 +1,324 @@
+package mail
+
+import (
+	"fmt"
+	"strings"
+
+	mdns "github.com/miekg/dns"
+)
+
+// SPFAnalysis holds the parsed/expanded SPF record for a domain.
+//
+// The lookup count covers every term that triggers an additional DNS query
+// per RFC 7208 §4.6.4: include, a, mx, ptr, exists, and the redirect modifier.
+// ip4, ip6, all, and exp do not count. The hard budget is 10; over that is a
+// PermError.
+//
+// Void lookups (NXDOMAIN or empty answers) tracked here are limited to
+// include/redirect targets — we don't simulate a/mx/exists resolution, so the
+// void counter only reflects what the structural walk observed.
+type SPFAnalysis struct {
+	Domain        string   `json:",omitempty"`
+	Records       []string `json:",omitempty"` // every v=spf1 TXT at the root domain
+	Root          *SPFNode `json:",omitempty"`
+	LookupCount   int
+	LookupLimit   int
+	VoidCount     int
+	VoidLimit     int
+	OverLimit     bool     `json:",omitempty"` // LookupCount > LookupLimit
+	OverVoidLimit bool     `json:",omitempty"` // VoidCount > VoidLimit
+	Multiple      bool     `json:",omitempty"` // multiple v=spf1 records at root
+	Errors        []string `json:",omitempty"`
+}
+
+// SPFNode is one term in the SPF tree.
+//
+// For include and redirect, Children holds the terms of the resolved child
+// SPF record. For other mechanisms, Children is empty.
+type SPFNode struct {
+	Term         string     `json:",omitempty"` // raw token, e.g. "include:_spf.google.com"
+	Qualifier    string     `json:",omitempty"` // "+", "-", "~", "?"
+	Mechanism    string     `json:",omitempty"` // include, a, mx, ptr, exists, redirect, ip4, ip6, all, exp, spf1
+	Target       string     `json:",omitempty"` // domain-spec, CIDR, etc.
+	Record       string     `json:",omitempty"` // raw SPF record returned for include/redirect
+	CountsLookup bool       `json:",omitempty"` // mechanism counts against the 10-lookup budget
+	Unresolved   bool       `json:",omitempty"` // macro target — counted but not recursed into
+	Void         bool       `json:",omitempty"` // include/redirect target had no SPF or NXDOMAIN
+	Ignored      bool       `json:",omitempty"` // not evaluated per RFC 7208 ordering (after `all`, or redirect when `all` present)
+	Error        string     `json:",omitempty"` // DNS error or structural error fetching the child record
+	Children     []*SPFNode `json:",omitempty"`
+}
+
+const (
+	spfLookupLimit = 10
+	spfVoidLimit   = 2
+	spfDepthLimit  = 10
+)
+
+// SPFLookupFunc fetches v=spf1 TXT records at domain.
+// Returns void=true when the domain has no v=spf1 record (or NXDOMAIN).
+type SPFLookupFunc func(domain string) (records []string, void bool, err error)
+
+// AnalyzeSPF builds an analysis tree rooted at domain.
+// All DNS access is routed through fetch. If fetch is nil, the package-default
+// lookup (using the configured resolver) is used.
+func AnalyzeSPF(domain string, fetch SPFLookupFunc) *SPFAnalysis {
+	if fetch == nil {
+		fetch = defaultSPFLookup
+	}
+	a := &SPFAnalysis{
+		Domain:      domain,
+		LookupLimit: spfLookupLimit,
+		VoidLimit:   spfVoidLimit,
+	}
+
+	records, void, err := fetch(domain)
+	if err != nil {
+		a.Errors = append(a.Errors, err.Error())
+		return a
+	}
+	if void || len(records) == 0 {
+		return a
+	}
+	a.Records = records
+	if len(records) > 1 {
+		a.Multiple = true
+	}
+
+	a.Root = parseSPFRecord(records[0])
+	visited := map[string]bool{normalizeSPFDomain(domain): true}
+	expandSPF(a.Root, fetch, visited, 0, a)
+
+	if a.LookupCount > spfLookupLimit {
+		a.OverLimit = true
+	}
+	if a.VoidCount > spfVoidLimit {
+		a.OverVoidLimit = true
+	}
+	return a
+}
+
+// parseSPFRecord splits a v=spf1 record into a root node whose children are
+// each term. Children of include/redirect are filled in by expandSPF.
+func parseSPFRecord(record string) *SPFNode {
+	root := &SPFNode{
+		Term:      "v=spf1",
+		Mechanism: "spf1",
+		Record:    record,
+	}
+	fields := strings.Fields(record)
+	if len(fields) == 0 {
+		return root
+	}
+	for _, f := range fields[1:] {
+		root.Children = append(root.Children, parseSPFTerm(f))
+	}
+	return root
+}
+
+func parseSPFTerm(term string) *SPFNode {
+	n := &SPFNode{Term: term}
+	body := term
+
+	// Modifiers (redirect=, exp=) carry no qualifier.
+	if eq := strings.Index(body, "="); eq > 0 {
+		name := strings.ToLower(body[:eq])
+		switch name {
+		case "redirect":
+			n.Mechanism = "redirect"
+			n.Target = body[eq+1:]
+			n.CountsLookup = true
+			if hasMacro(n.Target) {
+				n.Unresolved = true
+			}
+			return n
+		case "exp":
+			n.Mechanism = "exp"
+			n.Target = body[eq+1:]
+			return n
+		}
+	}
+
+	if body == "" {
+		return n
+	}
+	switch body[0] {
+	case '+', '-', '~', '?':
+		n.Qualifier = string(body[0])
+		body = body[1:]
+	}
+
+	name := body
+	target := ""
+	if i := strings.IndexAny(body, ":/"); i >= 0 {
+		name = body[:i]
+		target = strings.TrimPrefix(body[i:], ":")
+	}
+	n.Mechanism = strings.ToLower(name)
+	n.Target = target
+
+	switch n.Mechanism {
+	case "include", "a", "mx", "ptr", "exists":
+		n.CountsLookup = true
+		if hasMacro(n.Target) {
+			n.Unresolved = true
+		}
+	}
+	return n
+}
+
+func hasMacro(s string) bool {
+	return strings.Contains(s, "%{")
+}
+
+// normalizeSPFDomain lowercases and strips a trailing dot so cycle keys are
+// consistent regardless of input shape.
+func normalizeSPFDomain(s string) string {
+	return strings.ToLower(strings.TrimSuffix(s, "."))
+}
+
+// isSPFRecord reports whether s is a v=spf1 record per RFC 7208 §4.5:
+// the version section MUST be exactly "v=spf1" (case-insensitive per §12
+// ABNF), terminated by space or end of record. Rejects e.g. "v=spf10".
+func isSPFRecord(s string) bool {
+	const tag = "v=spf1"
+	if len(s) < len(tag) || !strings.EqualFold(s[:len(tag)], tag) {
+		return false
+	}
+	if len(s) == len(tag) {
+		return true
+	}
+	return s[len(tag)] == ' ' || s[len(tag)] == '\t'
+}
+
+func expandSPF(node *SPFNode, fetch SPFLookupFunc, visited map[string]bool, depth int, a *SPFAnalysis) {
+	if node == nil {
+		return
+	}
+
+	// RFC 7208 §5.1: mechanisms after `all` MUST be ignored.
+	// RFC 7208 §6.1: `redirect=` MUST be ignored if any `all` mechanism is present.
+	hasAll := false
+	cutoff := len(node.Children)
+	for i, c := range node.Children {
+		if c.Mechanism == "all" {
+			hasAll = true
+			cutoff = i
+			break
+		}
+	}
+	evaluated := func(i int, c *SPFNode) bool {
+		// Modifiers are positional-independent.
+		// redirect= is ignored if any `all` mechanism is present (§6.1).
+		// exp= is consulted only when a fail result occurs (§6.2); position
+		// vs. `all` doesn't apply.
+		if c.Mechanism == "redirect" {
+			return !hasAll
+		}
+		if c.Mechanism == "exp" {
+			return true
+		}
+		// Mechanisms after `all` are ignored (§5.1).
+		if hasAll && i > cutoff {
+			return false
+		}
+		return true
+	}
+
+	for i, c := range node.Children {
+		if !evaluated(i, c) {
+			c.Ignored = true
+			continue
+		}
+		if c.CountsLookup {
+			a.LookupCount++
+		}
+	}
+	if depth >= spfDepthLimit {
+		a.Errors = append(a.Errors, fmt.Sprintf("max SPF depth (%d) reached", spfDepthLimit))
+		return
+	}
+
+	for i, c := range node.Children {
+		if c.Mechanism != "include" && c.Mechanism != "redirect" {
+			continue
+		}
+		if c.Ignored || !evaluated(i, c) {
+			continue
+		}
+		if c.Unresolved || c.Target == "" {
+			continue
+		}
+		target := normalizeSPFDomain(c.Target)
+		if visited[target] {
+			c.Error = "cycle"
+			continue
+		}
+		records, void, err := fetch(c.Target)
+		if err != nil {
+			c.Error = err.Error()
+			continue
+		}
+		if void || len(records) == 0 {
+			c.Void = true
+			a.VoidCount++
+			continue
+		}
+		if len(records) > 1 {
+			c.Error = "multiple SPF records"
+			continue
+		}
+		c.Record = records[0]
+		sub := parseSPFRecord(records[0])
+		c.Children = sub.Children
+		visited[target] = true
+		expandSPF(c, fetch, visited, depth+1, a)
+		delete(visited, target) // path-scoped: sibling re-visits are fine
+	}
+}
+
+// defaultSPFLookup queries TXT records at domain via the configured resolver
+// and filters for v=spf1. Returns void=true on NXDOMAIN or when no v=spf1
+// record is present.
+func defaultSPFLookup(domain string) ([]string, bool, error) {
+	resolver := findResolver()
+	qname := strings.TrimSuffix(domain, ".") + "."
+
+	msg := new(mdns.Msg)
+	msg.SetQuestion(qname, mdns.TypeTXT)
+	msg.RecursionDesired = true
+
+	client := &mdns.Client{Timeout: timeout}
+	resp, _, err := client.Exchange(msg, resolver)
+	if err != nil {
+		return nil, false, err
+	}
+	if resp.Truncated {
+		tcpClient := &mdns.Client{Timeout: timeout, Net: "tcp"}
+		resp, _, err = tcpClient.Exchange(msg, resolver)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	switch resp.Rcode {
+	case mdns.RcodeSuccess:
+	case mdns.RcodeNameError:
+		return nil, true, nil
+	default:
+		return nil, false, fmt.Errorf("DNS query failed: %s", mdns.RcodeToString[resp.Rcode])
+	}
+
+	var spfs []string
+	for _, r := range resp.Answer {
+		if txt, ok := r.(*mdns.TXT); ok {
+			val := strings.Join(txt.Txt, "")
+			if isSPFRecord(val) {
+				spfs = append(spfs, val)
+			}
+		}
+	}
+	if len(spfs) == 0 {
+		return nil, true, nil
+	}
+	return spfs, false, nil
+}

--- a/internal/mail/spf_test.go
+++ b/internal/mail/spf_test.go
@@ -1,0 +1,710 @@
+package mail
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	mdns "github.com/miekg/dns"
+)
+
+// stubLookup builds an SPFLookupFunc from a static map of domain → records.
+// A domain mapped to nil returns void. Unknown domains return NXDOMAIN-style void.
+type stubLookup struct {
+	records map[string][]string
+	errs    map[string]error
+	calls   map[string]int
+}
+
+func newStub() *stubLookup {
+	return &stubLookup{
+		records: map[string][]string{},
+		errs:    map[string]error{},
+		calls:   map[string]int{},
+	}
+}
+
+func (s *stubLookup) set(domain string, records ...string) *stubLookup {
+	s.records[strings.ToLower(domain)] = records
+	return s
+}
+
+func (s *stubLookup) void(domain string) *stubLookup {
+	s.records[strings.ToLower(domain)] = nil
+	return s
+}
+
+func (s *stubLookup) fail(domain string, err error) *stubLookup {
+	s.errs[strings.ToLower(domain)] = err
+	return s
+}
+
+func (s *stubLookup) fn() SPFLookupFunc {
+	return func(domain string) ([]string, bool, error) {
+		key := strings.ToLower(strings.TrimSuffix(domain, "."))
+		s.calls[key]++
+		if err, ok := s.errs[key]; ok {
+			return nil, false, err
+		}
+		recs, present := s.records[key]
+		if !present {
+			return nil, true, nil
+		}
+		if len(recs) == 0 {
+			return nil, true, nil
+		}
+		return recs, false, nil
+	}
+}
+
+func TestAnalyzeSPF_CountsLookupMechanisms(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 ip4:1.2.3.4 a mx ptr exists:%{i}._spf.example.com -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.LookupCount != 4 {
+		t.Fatalf("LookupCount = %d, want 4 (a + mx + ptr + exists)", a.LookupCount)
+	}
+	if a.OverLimit {
+		t.Fatal("OverLimit set unexpectedly")
+	}
+	if a.Root == nil {
+		t.Fatal("Root nil")
+	}
+	if len(a.Root.Children) != 6 {
+		t.Fatalf("Root.Children = %d, want 6", len(a.Root.Children))
+	}
+}
+
+func TestAnalyzeSPF_IncludeRedirectExpand(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 include:_spf.google.com redirect=fallback.example.com").
+		set("_spf.google.com", "v=spf1 include:_netblocks.google.com -all").
+		set("_netblocks.google.com", "v=spf1 ip4:64.233.160.0/19 -all").
+		set("fallback.example.com", "v=spf1 ip4:5.6.7.8 -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	// include + redirect + nested include = 3 lookups.
+	if a.LookupCount != 3 {
+		t.Fatalf("LookupCount = %d, want 3", a.LookupCount)
+	}
+	if a.Root == nil || len(a.Root.Children) != 2 {
+		t.Fatalf("expected 2 root children")
+	}
+	inc := a.Root.Children[0]
+	if inc.Mechanism != "include" {
+		t.Fatalf("first child mechanism = %q", inc.Mechanism)
+	}
+	if len(inc.Children) == 0 {
+		t.Fatal("include not expanded")
+	}
+	if inc.Children[0].Mechanism != "include" {
+		t.Fatalf("nested mechanism = %q", inc.Children[0].Mechanism)
+	}
+	if len(inc.Children[0].Children) == 0 {
+		t.Fatal("nested include not expanded")
+	}
+}
+
+func TestAnalyzeSPF_MacroNotRecursed(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 exists:%{ir}.spf.example.com include:%{d}.spf.example.com -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	// Both macro terms count, neither expanded.
+	if a.LookupCount != 2 {
+		t.Fatalf("LookupCount = %d, want 2", a.LookupCount)
+	}
+	for _, c := range a.Root.Children {
+		if c.CountsLookup && !c.Unresolved {
+			t.Fatalf("term %q expected Unresolved=true", c.Term)
+		}
+	}
+	// Should not have queried macro targets.
+	if stub.calls["%{ir}.spf.example.com"] != 0 || stub.calls["%{d}.spf.example.com"] != 0 {
+		t.Fatalf("macro targets were queried: %v", stub.calls)
+	}
+}
+
+func TestAnalyzeSPF_CycleDetection(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 include:loop.example.com -all").
+		set("loop.example.com", "v=spf1 include:example.com -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.LookupCount != 2 {
+		t.Fatalf("LookupCount = %d, want 2", a.LookupCount)
+	}
+	cycleNode := a.Root.Children[0].Children[0]
+	if cycleNode.Mechanism != "include" || cycleNode.Target != "example.com" {
+		t.Fatalf("unexpected cycle node: %+v", cycleNode)
+	}
+	if cycleNode.Error != "cycle" {
+		t.Fatalf("cycle node Error = %q, want %q", cycleNode.Error, "cycle")
+	}
+}
+
+func TestAnalyzeSPF_VoidLookups(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 include:gone.example.com include:empty.example.com include:also-gone.example.com -all").
+		void("empty.example.com")
+	// gone and also-gone deliberately not in stub → NXDOMAIN-style void
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.VoidCount != 3 {
+		t.Fatalf("VoidCount = %d, want 3", a.VoidCount)
+	}
+	if !a.OverVoidLimit {
+		t.Fatal("OverVoidLimit not set")
+	}
+}
+
+func TestAnalyzeSPF_OverLimit(t *testing.T) {
+	// 11 includes pointing at terminal records → 11 lookups.
+	root := strings.Builder{}
+	root.WriteString("v=spf1")
+	stub := newStub()
+	for i := 0; i < 11; i++ {
+		d := "leaf" + string(rune('a'+i)) + ".example.com"
+		root.WriteString(" include:" + d)
+		stub.set(d, "v=spf1 -all")
+	}
+	root.WriteString(" -all")
+	stub.set("example.com", root.String())
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.LookupCount != 11 {
+		t.Fatalf("LookupCount = %d, want 11", a.LookupCount)
+	}
+	if !a.OverLimit {
+		t.Fatal("OverLimit not set for 11 lookups")
+	}
+}
+
+func TestAnalyzeSPF_MultipleRootRecords(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 ip4:1.2.3.4 -all", "v=spf1 ip4:5.6.7.8 -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if !a.Multiple {
+		t.Fatal("Multiple not set")
+	}
+	if len(a.Records) != 2 {
+		t.Fatalf("Records = %d, want 2", len(a.Records))
+	}
+}
+
+func TestAnalyzeSPF_NoRecord(t *testing.T) {
+	stub := newStub().void("example.com")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.Root != nil {
+		t.Fatal("Root should be nil when no SPF record")
+	}
+	if a.LookupCount != 0 {
+		t.Fatalf("LookupCount = %d, want 0", a.LookupCount)
+	}
+}
+
+func TestAnalyzeSPF_RootFetchError(t *testing.T) {
+	stub := newStub().fail("example.com", errors.New("connection refused"))
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if len(a.Errors) != 1 || !strings.Contains(a.Errors[0], "connection refused") {
+		t.Fatalf("Errors = %v", a.Errors)
+	}
+}
+
+func TestAnalyzeSPF_IncludeFetchError(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 include:broken.example.com -all").
+		fail("broken.example.com", errors.New("timeout"))
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.LookupCount != 1 {
+		t.Fatalf("LookupCount = %d, want 1", a.LookupCount)
+	}
+	got := a.Root.Children[0]
+	if got.Error == "" || !strings.Contains(got.Error, "timeout") {
+		t.Fatalf("expected timeout error, got %q", got.Error)
+	}
+	// Errored include should not increment void counter.
+	if a.VoidCount != 0 {
+		t.Fatalf("VoidCount = %d, want 0", a.VoidCount)
+	}
+}
+
+func TestAnalyzeSPF_IncludeMultipleRecords(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 include:dupes.example.com -all").
+		set("dupes.example.com", "v=spf1 -all", "v=spf1 ip4:1.2.3.4 -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	got := a.Root.Children[0]
+	if got.Error != "multiple SPF records" {
+		t.Fatalf("Error = %q, want %q", got.Error, "multiple SPF records")
+	}
+}
+
+func TestParseSPFTerm_Mechanisms(t *testing.T) {
+	tests := []struct {
+		in           string
+		mech         string
+		qual         string
+		target       string
+		countsLookup bool
+		unresolved   bool
+	}{
+		{"+ip4:1.2.3.4", "ip4", "+", "1.2.3.4", false, false},
+		{"-all", "all", "-", "", false, false},
+		{"~all", "all", "~", "", false, false},
+		{"?all", "all", "?", "", false, false},
+		{"include:_spf.google.com", "include", "", "_spf.google.com", true, false},
+		{"a", "a", "", "", true, false},
+		{"a:mail.example.com", "a", "", "mail.example.com", true, false},
+		{"a/24", "a", "", "/24", true, false},
+		{"mx", "mx", "", "", true, false},
+		{"ptr:example.com", "ptr", "", "example.com", true, false},
+		{"exists:%{i}._spf.mta.salesforce.com", "exists", "", "%{i}._spf.mta.salesforce.com", true, true},
+		{"redirect=spf.example.com", "redirect", "", "spf.example.com", true, false},
+		{"exp=explain.example.com", "exp", "", "explain.example.com", false, false},
+	}
+	for _, tt := range tests {
+		got := parseSPFTerm(tt.in)
+		if got.Mechanism != tt.mech {
+			t.Errorf("%q: Mechanism = %q, want %q", tt.in, got.Mechanism, tt.mech)
+		}
+		if got.Qualifier != tt.qual {
+			t.Errorf("%q: Qualifier = %q, want %q", tt.in, got.Qualifier, tt.qual)
+		}
+		if got.Target != tt.target {
+			t.Errorf("%q: Target = %q, want %q", tt.in, got.Target, tt.target)
+		}
+		if got.CountsLookup != tt.countsLookup {
+			t.Errorf("%q: CountsLookup = %v, want %v", tt.in, got.CountsLookup, tt.countsLookup)
+		}
+		if got.Unresolved != tt.unresolved {
+			t.Errorf("%q: Unresolved = %v, want %v", tt.in, got.Unresolved, tt.unresolved)
+		}
+	}
+}
+
+func TestAnalyzeSPF_DeepNesting(t *testing.T) {
+	// Chain of single includes to verify depth limit triggers an error rather
+	// than runaway recursion.
+	stub := newStub()
+	stub.set("d0.example.com", "v=spf1 include:d1.example.com -all")
+	for i := 1; i <= spfDepthLimit+2; i++ {
+		from := "d" + itoa(i) + ".example.com"
+		next := "d" + itoa(i+1) + ".example.com"
+		stub.set(from, "v=spf1 include:"+next+" -all")
+	}
+	stub.set("d"+itoa(spfDepthLimit+3)+".example.com", "v=spf1 -all")
+
+	a := AnalyzeSPF("d0.example.com", stub.fn())
+
+	hasDepthErr := false
+	for _, e := range a.Errors {
+		if strings.Contains(e, "max SPF depth") {
+			hasDepthErr = true
+			break
+		}
+	}
+	if !hasDepthErr {
+		t.Fatalf("expected max-depth error, got %v", a.Errors)
+	}
+}
+
+func TestAnalyzeSPF_RedirectIgnoredWhenAllPresent(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 -all redirect=fallback.example.com").
+		set("fallback.example.com", "v=spf1 ip4:1.2.3.4 -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.LookupCount != 0 {
+		t.Fatalf("LookupCount = %d, want 0 (redirect ignored when all is present)", a.LookupCount)
+	}
+	if stub.calls["fallback.example.com"] != 0 {
+		t.Fatalf("redirect target was queried despite all mechanism present")
+	}
+	// redirect node should be flagged Ignored.
+	var redirect *SPFNode
+	for _, c := range a.Root.Children {
+		if c.Mechanism == "redirect" {
+			redirect = c
+			break
+		}
+	}
+	if redirect == nil || !redirect.Ignored {
+		t.Fatalf("redirect node not flagged Ignored: %+v", redirect)
+	}
+}
+
+func TestAnalyzeSPF_AllItselfNotIgnored(t *testing.T) {
+	// The matching `all` mechanism is the terminating action — it is evaluated,
+	// not ignored. Only mechanisms textually after it should be flagged.
+	stub := newStub().
+		set("example.com", "v=spf1 ip4:1.2.3.4 -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	for _, c := range a.Root.Children {
+		if c.Mechanism == "all" && c.Ignored {
+			t.Fatalf("all mechanism flagged Ignored: %+v", c)
+		}
+	}
+}
+
+func TestAnalyzeSPF_ExpAfterAllNotIgnored(t *testing.T) {
+	// exp= is a modifier that applies on fail results regardless of position.
+	// It must not be flagged Ignored just because it appears after `all`.
+	stub := newStub().
+		set("example.com", "v=spf1 ip4:1.2.3.4 -all exp=explain.example.com")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	var exp *SPFNode
+	for _, c := range a.Root.Children {
+		if c.Mechanism == "exp" {
+			exp = c
+			break
+		}
+	}
+	if exp == nil {
+		t.Fatal("exp node not present")
+	}
+	if exp.Ignored {
+		t.Fatalf("exp flagged Ignored: %+v", exp)
+	}
+}
+
+func TestAnalyzeSPF_RootTrailingDotCycle(t *testing.T) {
+	// Root passed with a trailing dot must still be recognized as a cycle
+	// when a child includes the same domain without the dot.
+	stub := newStub().
+		set("example.com", "v=spf1 include:example.com -all")
+
+	a := AnalyzeSPF("example.com.", stub.fn())
+
+	if a.LookupCount != 1 {
+		t.Fatalf("LookupCount = %d, want 1", a.LookupCount)
+	}
+	child := a.Root.Children[0]
+	if child.Error != "cycle" {
+		t.Fatalf("expected cycle on root self-include, got Error=%q", child.Error)
+	}
+}
+
+func TestAnalyzeSPF_TermsAfterAllIgnored(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 ip4:1.2.3.4 -all include:should-not-count.example.com a:mail.example.com")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.LookupCount != 0 {
+		t.Fatalf("LookupCount = %d, want 0 (terms after all ignored)", a.LookupCount)
+	}
+	if stub.calls["should-not-count.example.com"] != 0 {
+		t.Fatalf("term after all was queried")
+	}
+	var inc, after *SPFNode
+	for _, c := range a.Root.Children {
+		switch c.Term {
+		case "include:should-not-count.example.com":
+			inc = c
+		case "a:mail.example.com":
+			after = c
+		}
+	}
+	if inc == nil || !inc.Ignored {
+		t.Fatalf("include after all not Ignored: %+v", inc)
+	}
+	if after == nil || !after.Ignored {
+		t.Fatalf("a after all not Ignored: %+v", after)
+	}
+}
+
+func TestAnalyzeSPF_RepeatedIncludeNoFalseCycle(t *testing.T) {
+	// Same include used in two sibling positions should both be expanded —
+	// not flagged as a cycle. Path-scoped visited set required.
+	stub := newStub().
+		set("example.com", "v=spf1 include:_spf.shared.com include:_spf.shared.com -all").
+		set("_spf.shared.com", "v=spf1 ip4:1.2.3.4 -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.LookupCount != 2 {
+		t.Fatalf("LookupCount = %d, want 2", a.LookupCount)
+	}
+	for i, c := range a.Root.Children {
+		if c.Mechanism != "include" {
+			continue
+		}
+		if c.Error == "cycle" {
+			t.Fatalf("child %d falsely flagged as cycle", i)
+		}
+		if len(c.Children) == 0 {
+			t.Fatalf("child %d not expanded", i)
+		}
+	}
+}
+
+func TestAnalyzeSPF_RealCycleStillDetected(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 include:loop.example.com -all").
+		set("loop.example.com", "v=spf1 include:example.com -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	cycleNode := a.Root.Children[0].Children[0]
+	if cycleNode.Error != "cycle" {
+		t.Fatalf("expected cycle, got %q", cycleNode.Error)
+	}
+}
+
+func TestAnalyzeSPF_RedirectChain(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 redirect=a.example.com").
+		set("a.example.com", "v=spf1 redirect=b.example.com").
+		set("b.example.com", "v=spf1 ip4:1.2.3.4 -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.LookupCount != 2 {
+		t.Fatalf("LookupCount = %d, want 2", a.LookupCount)
+	}
+	first := a.Root.Children[0]
+	if first.Mechanism != "redirect" || len(first.Children) == 0 {
+		t.Fatalf("redirect not expanded: %+v", first)
+	}
+	second := first.Children[0]
+	if second.Mechanism != "redirect" || len(second.Children) == 0 {
+		t.Fatalf("nested redirect not expanded: %+v", second)
+	}
+}
+
+func TestAnalyzeSPF_RootDomainTrailingDot(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 include:_spf.example.com -all").
+		set("_spf.example.com", "v=spf1 ip4:1.2.3.4 -all")
+
+	a := AnalyzeSPF("example.com.", stub.fn())
+
+	if a.LookupCount != 1 {
+		t.Fatalf("LookupCount = %d, want 1", a.LookupCount)
+	}
+	if a.Root == nil || len(a.Root.Children) == 0 {
+		t.Fatal("root not parsed")
+	}
+}
+
+func TestAnalyzeSPF_QualifiedInclude(t *testing.T) {
+	stub := newStub().
+		set("example.com", "v=spf1 +include:plus.example.com ?include:question.example.com ~include:tilde.example.com -include:minus.example.com -all").
+		set("plus.example.com", "v=spf1 -all").
+		set("question.example.com", "v=spf1 -all").
+		set("tilde.example.com", "v=spf1 -all").
+		set("minus.example.com", "v=spf1 -all")
+
+	a := AnalyzeSPF("example.com", stub.fn())
+
+	if a.LookupCount != 4 {
+		t.Fatalf("LookupCount = %d, want 4", a.LookupCount)
+	}
+	wantQuals := []string{"+", "?", "~", "-"}
+	for i, q := range wantQuals {
+		if a.Root.Children[i].Qualifier != q {
+			t.Errorf("child %d qualifier = %q, want %q", i, a.Root.Children[i].Qualifier, q)
+		}
+		if a.Root.Children[i].Mechanism != "include" {
+			t.Errorf("child %d mechanism = %q, want include", i, a.Root.Children[i].Mechanism)
+		}
+	}
+}
+
+// startSPFDNSServer spins up a UDP+TCP DNS server and returns its address.
+// Each handler call serves whatever TXT records are configured for the
+// queried name. Names not in the map return NXDOMAIN.
+func startSPFDNSServer(t *testing.T, records map[string][]string) string {
+	t.Helper()
+
+	udpConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := udpConn.LocalAddr().String()
+	tcpLn, err := net.Listen("tcp", addr)
+	if err != nil {
+		_ = udpConn.Close()
+		t.Fatal(err)
+	}
+
+	handler := mdns.HandlerFunc(func(w mdns.ResponseWriter, r *mdns.Msg) {
+		m := new(mdns.Msg)
+		m.SetReply(r)
+		if len(r.Question) == 0 || r.Question[0].Qtype != mdns.TypeTXT {
+			_ = w.WriteMsg(m)
+			return
+		}
+		name := strings.TrimSuffix(strings.ToLower(r.Question[0].Name), ".")
+		txts, ok := records[name]
+		if !ok {
+			m.Rcode = mdns.RcodeNameError
+			_ = w.WriteMsg(m)
+			return
+		}
+		for _, t := range txts {
+			m.Answer = append(m.Answer, &mdns.TXT{
+				Hdr: mdns.RR_Header{Name: r.Question[0].Name, Rrtype: mdns.TypeTXT, Class: mdns.ClassINET, Ttl: 60},
+				Txt: []string{t},
+			})
+		}
+		_ = w.WriteMsg(m)
+	})
+
+	udpServer := &mdns.Server{PacketConn: udpConn, Handler: handler, Net: "udp"}
+	tcpServer := &mdns.Server{Listener: tcpLn, Handler: handler, Net: "tcp"}
+	go func() { _ = udpServer.ActivateAndServe() }()
+	go func() { _ = tcpServer.ActivateAndServe() }()
+	t.Cleanup(func() {
+		_ = udpServer.Shutdown()
+		_ = tcpServer.Shutdown()
+	})
+	return addr
+}
+
+// withSPFResolver swaps the package-level resolver lookup for the duration
+// of t by setting QUIEN_RESOLVER, which findResolver() honors.
+func withSPFResolver(t *testing.T, addr string) {
+	t.Helper()
+	t.Setenv("QUIEN_RESOLVER", addr)
+}
+
+func TestDefaultSPFLookup_FiltersNonSPFTXT(t *testing.T) {
+	addr := startSPFDNSServer(t, map[string][]string{
+		"example.com": {
+			"some-other-txt-value",
+			"v=spf1 ip4:1.2.3.4 -all",
+			"v=DMARC1; p=reject", // wrong tag
+			"v=spf10 -all",       // looks similar but not SPF
+		},
+	})
+	withSPFResolver(t, addr)
+
+	recs, void, err := defaultSPFLookup("example.com")
+	if err != nil {
+		t.Fatalf("defaultSPFLookup error: %v", err)
+	}
+	if void {
+		t.Fatal("void = true, want false")
+	}
+	if len(recs) != 1 {
+		t.Fatalf("recs = %v, want exactly the one v=spf1 record", recs)
+	}
+	if recs[0] != "v=spf1 ip4:1.2.3.4 -all" {
+		t.Fatalf("unexpected record: %q", recs[0])
+	}
+}
+
+func TestDefaultSPFLookup_NXDOMAINIsVoid(t *testing.T) {
+	addr := startSPFDNSServer(t, map[string][]string{}) // nothing configured
+	withSPFResolver(t, addr)
+
+	recs, void, err := defaultSPFLookup("missing.example.com")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !void || recs != nil {
+		t.Fatalf("recs=%v void=%v, want nil/true", recs, void)
+	}
+}
+
+func TestDefaultSPFLookup_NoSPFTXTIsVoid(t *testing.T) {
+	addr := startSPFDNSServer(t, map[string][]string{
+		"example.com": {"v=DMARC1; p=reject"},
+	})
+	withSPFResolver(t, addr)
+
+	recs, void, err := defaultSPFLookup("example.com")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !void || recs != nil {
+		t.Fatalf("recs=%v void=%v, want nil/true", recs, void)
+	}
+}
+
+func TestDefaultSPFLookup_MultipleSPFRecords(t *testing.T) {
+	addr := startSPFDNSServer(t, map[string][]string{
+		"example.com": {
+			"v=spf1 ip4:1.2.3.4 -all",
+			"v=spf1 ip4:5.6.7.8 -all",
+		},
+	})
+	withSPFResolver(t, addr)
+
+	recs, void, err := defaultSPFLookup("example.com")
+	if err != nil || void {
+		t.Fatalf("err=%v void=%v", err, void)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("recs = %d, want 2", len(recs))
+	}
+}
+
+func TestIsSPFRecord(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"v=spf1", true},
+		{"v=spf1 -all", true},
+		{"v=spf1\t-all", true},
+		{"v=spf10 -all", false},
+		{"v=spf1foo", false},
+		{"V=spf1 -all", true}, // version is case-insensitive per RFC 7208 §12 ABNF
+		{"", false},
+		{"spf1", false},
+	}
+	for _, tt := range tests {
+		if got := isSPFRecord(tt.in); got != tt.want {
+			t.Errorf("isSPFRecord(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+// itoa is a tiny helper to avoid pulling in strconv in test helpers.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
Closes #30.

Resolves SPF records into a structural analysis tree per RFC 7208: counts lookup-causing mechanisms (`include`, `a`, `mx`, `ptr`, `exists`, `redirect`) against the 10-lookup budget, walks `include`/`redirect` chains, and surfaces void lookups, multi-record PermErrors, cycles, and macro targets that can't be statically resolved.

## Mail tab

- New `Lookups N / 10` row colored green / yellow (≥8) / red (PermError).
- New `Inc voids` row when include/redirect targets return NXDOMAIN or no SPF record.
- Indented tree rendering of every term with annotations for ignored / void / macro / error states.
- `x` expands one more layer (caps at deepest meaningful level, then collapses).
- `X` jumps to full expansion (or collapses if already there).
- Footer hint reflects current state: `x/X expand spf` → `x more  X all` → `x/X collapse spf`.

## JSON

`quien mail` and `quien all` now include a `SPFAnalysis` field on domains with an SPF record, holding the parsed tree plus lookup count, void count, and PermError flags. The field is omitted when there is no SPF record (no behavioral change for non-SPF domains).

## RFC compliance details

- `all` short-circuits: mechanisms after `all` get an `Ignored` flag and don't count or expand (§5.1). The matching `all` itself is evaluated, not ignored.
- `redirect=` is ignored if any `all` mechanism is present anywhere in the record (§6.1), regardless of textual position.
- `exp=` is treated as a position-independent modifier and is never marked `Ignored`.
- Void lookup counter capped at 2 (§4.6.4); only counts include/redirect voids since `a`/`mx`/`exists` are not resolved at analysis time.
- Path-scoped visited set: sibling re-uses of the same include don't false-cycle, but real cycles still trip the `cycle` flag.
- Strict version match: `v=spf1` must be terminated by space, tab, or end of record (rejects `v=spf10`); case-insensitive per §12 ABNF.
- Multiple `v=spf1` records at the root surface a `Multiple` PermError flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)