### PR TITLE
Allow configurable DKIM selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ quien seo example.com
 quien stack example.com
 quien all example.com
 
+# Probe additional DKIM selectors beyond the built-in common list
+quien mail example.com --dkim-selector mySelector --dkim-selector other
+
+# Set default DKIM selectors via environment variable
+QUIEN_DKIM_SELECTORS=mySelector,other quien example.com
+
 # Use a specific DNS resolver for this run
 quien mail example.com --resolver 9.9.9.9
 
@@ -90,6 +96,8 @@ QUIEN_RESOLVER=1.1.1.1 quien dns example.com
 ```
 
 Resolver precedence: `--resolver` > `QUIEN_RESOLVER` > system resolver.
+
+DKIM selector precedence: `--dkim-selector` > `QUIEN_DKIM_SELECTORS`. User selectors are probed in addition to the built-in common-selector list.
 
 ## Core Web Vitals
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/retlehs/quien/internal/display"
 	"github.com/retlehs/quien/internal/dnsutil"
+	"github.com/retlehs/quien/internal/mail"
 	"github.com/retlehs/quien/internal/resolver"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -16,6 +17,7 @@ import (
 
 var jsonFlag bool
 var resolverFlag string
+var dkimSelectorFlag []string
 
 var rootCmd = &cobra.Command{
 	Use:          "quien [domain or IP]",
@@ -24,6 +26,12 @@ var rootCmd = &cobra.Command{
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(dkimSelectorFlag) > 0 {
+			if err := os.Setenv(mail.DKIMSelectorsEnvVar, strings.Join(dkimSelectorFlag, ",")); err != nil {
+				return err
+			}
+		}
+
 		if resolverFlag != "" {
 			normalized, err := dnsutil.NormalizeResolver(resolverFlag)
 			if err != nil {
@@ -127,6 +135,7 @@ func runLookup(input string, isIP bool) error {
 func init() {
 	rootCmd.Flags().BoolVar(&jsonFlag, "json", false, "output as JSON")
 	rootCmd.PersistentFlags().StringVar(&resolverFlag, "resolver", "", "DNS resolver to use for DNS/mail lookups (host or host:port). Overrides "+dnsutil.ResolverEnvVar)
+	rootCmd.PersistentFlags().StringSliceVar(&dkimSelectorFlag, "dkim-selector", nil, "DKIM selector(s) to probe in addition to the built-in common list (repeatable, comma-separated). Overrides "+mail.DKIMSelectorsEnvVar)
 }
 
 func Execute(version, commit, date string) {

--- a/internal/display/mail.go
+++ b/internal/display/mail.go
@@ -81,7 +81,7 @@ func RenderMail(records *mail.Records, mxResolutions []mail.MXResolution, spfDep
 			b.WriteString(wrapRecord(dk.Value))
 		}
 	} else {
-		b.WriteString(row("Status", dimStyle.Render("no records found (checked common selectors)")))
+		b.WriteString(row("Status", dimStyle.Render("no records found for checked selectors")))
 	}
 
 	// BIMI

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -12,6 +13,10 @@ import (
 	mdns "github.com/miekg/dns"
 	"github.com/retlehs/quien/internal/dnsutil"
 )
+
+// DKIMSelectorsEnvVar holds a comma-separated list of DKIM selectors that are
+// probed in addition to the built-in common-selector list.
+const DKIMSelectorsEnvVar = "QUIEN_DKIM_SELECTORS"
 
 type Records struct {
 	MX          []MXRecord
@@ -70,10 +75,32 @@ var dkimSelectors = []string{
 	"sig1", // Hubspot
 }
 
+// LookupOptions tunes Lookup behavior.
+type LookupOptions struct {
+	// DKIMSelectors are user-supplied selectors probed in addition to the
+	// built-in common-selector list. User selectors are probed first; the
+	// merged list is deduped (case-insensitive, whitespace-trimmed).
+	// When empty, QUIEN_DKIM_SELECTORS is consulted as a fallback.
+	DKIMSelectors []string
+}
+
 // Lookup queries MX, SPF, DKIM, and DMARC records for the given domain.
+// User selectors from QUIEN_DKIM_SELECTORS, if set, are probed alongside the
+// built-in common-selector list.
 func Lookup(domain string) (*Records, error) {
+	return LookupWithOptions(domain, LookupOptions{})
+}
+
+// LookupWithOptions is Lookup with caller-controlled options. When
+// opts.DKIMSelectors is empty, QUIEN_DKIM_SELECTORS is used as a fallback.
+func LookupWithOptions(domain string, opts LookupOptions) (*Records, error) {
 	resolver := findResolver()
 	records := &Records{}
+
+	userSelectors := opts.DKIMSelectors
+	if len(userSelectors) == 0 {
+		userSelectors = selectorsFromEnv()
+	}
 
 	// MX
 	if rr, err := query(domain+".", mdns.TypeMX, resolver); err == nil {
@@ -129,25 +156,87 @@ func Lookup(domain string) (*Records, error) {
 		records.BIMI.VMC = fetchVMC(records.BIMI.VMCURL)
 	}
 
-	// DKIM — probe common selectors
-	for _, sel := range dkimSelectors {
-		qname := sel + "._domainkey." + domain + "."
-		if rr, err := query(qname, mdns.TypeTXT, resolver); err == nil {
-			for _, r := range rr {
-				if txt, ok := r.(*mdns.TXT); ok {
-					val := strings.Join(txt.Txt, "")
-					if strings.Contains(strings.ToLower(val), "v=dkim1") {
-						records.DKIM = append(records.DKIM, DKIMRecord{
-							Selector: sel,
-							Value:    val,
-						})
-					}
-				}
-			}
-		}
-	}
+	// DKIM — probe merged selector list in parallel
+	records.DKIM = lookupDKIM(domain, mergeDKIMSelectors(userSelectors, dkimSelectors), resolver)
 
 	return records, nil
+}
+
+// selectorsFromEnv parses QUIEN_DKIM_SELECTORS into a slice. The env var is a
+// comma-separated list; whitespace is trimmed and empty entries are dropped.
+func selectorsFromEnv() []string {
+	raw := strings.TrimSpace(os.Getenv(DKIMSelectorsEnvVar))
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// mergeDKIMSelectors returns user selectors first, then defaults, deduped
+// (case-insensitive after trimming) and dropping any empty entries.
+func mergeDKIMSelectors(user, defaults []string) []string {
+	merged := make([]string, 0, len(user)+len(defaults))
+	seen := map[string]struct{}{}
+	for _, src := range [][]string{user, defaults} {
+		for _, s := range src {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			key := strings.ToLower(s)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			merged = append(merged, s)
+		}
+	}
+	return merged
+}
+
+// lookupDKIM probes each selector concurrently and returns matching v=DKIM1
+// TXT records in selector-order.
+func lookupDKIM(domain string, selectors []string, resolver string) []DKIMRecord {
+	if len(selectors) == 0 {
+		return nil
+	}
+	results := make([][]DKIMRecord, len(selectors))
+	var wg sync.WaitGroup
+	for i, sel := range selectors {
+		wg.Add(1)
+		go func(i int, sel string) {
+			defer wg.Done()
+			qname := sel + "._domainkey." + domain + "."
+			rr, err := query(qname, mdns.TypeTXT, resolver)
+			if err != nil {
+				return
+			}
+			for _, r := range rr {
+				txt, ok := r.(*mdns.TXT)
+				if !ok {
+					continue
+				}
+				val := strings.Join(txt.Txt, "")
+				if strings.Contains(strings.ToLower(val), "v=dkim1") {
+					results[i] = append(results[i], DKIMRecord{Selector: sel, Value: val})
+				}
+			}
+		}(i, sel)
+	}
+	wg.Wait()
+
+	var out []DKIMRecord
+	for _, r := range results {
+		out = append(out, r...)
+	}
+	return out
 }
 
 // MXResolution pairs an MX host with its resolved IP addresses (and reverse DNS).

--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -2,6 +2,8 @@ package mail
 
 import (
 	"net"
+	"reflect"
+	"strings"
 	"testing"
 
 	mdns "github.com/miekg/dns"
@@ -84,6 +86,164 @@ func TestQueryTCPFallbackOnTruncation(t *testing.T) {
 
 	if found == "" {
 		t.Errorf("expected SPF record %q in TCP response, got none", spf)
+	}
+}
+
+func TestMergeDKIMSelectors(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     []string
+		defaults []string
+		want     []string
+	}{
+		{
+			name:     "no user selectors keeps defaults in order",
+			defaults: []string{"default", "google", "selector1"},
+			want:     []string{"default", "google", "selector1"},
+		},
+		{
+			name:     "user selectors come first",
+			user:     []string{"foo", "bar"},
+			defaults: []string{"default", "google"},
+			want:     []string{"foo", "bar", "default", "google"},
+		},
+		{
+			name:     "dedupes case-insensitively, preserving user spelling",
+			user:     []string{"Google", "custom"},
+			defaults: []string{"default", "google"},
+			want:     []string{"Google", "custom", "default"},
+		},
+		{
+			name:     "trims whitespace and drops empty entries",
+			user:     []string{"  foo  ", "", "   "},
+			defaults: []string{"default"},
+			want:     []string{"foo", "default"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeDKIMSelectors(tc.user, tc.defaults)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("mergeDKIMSelectors(%v, %v) = %v, want %v", tc.user, tc.defaults, got, tc.want)
+			}
+		})
+	}
+}
+
+// startDKIMServer spins up a UDP DNS server that returns a v=DKIM1 TXT record
+// for each selector in records, and NXDOMAIN otherwise.
+func startDKIMServer(t *testing.T, domain string, records map[string]string) string {
+	t.Helper()
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := mdns.HandlerFunc(func(w mdns.ResponseWriter, r *mdns.Msg) {
+		m := new(mdns.Msg)
+		m.SetReply(r)
+		q := r.Question[0]
+		suffix := "._domainkey." + domain + "."
+		if q.Qtype == mdns.TypeTXT && strings.HasSuffix(q.Name, suffix) {
+			sel := strings.TrimSuffix(q.Name, suffix)
+			if val, ok := records[sel]; ok {
+				m.Answer = append(m.Answer, &mdns.TXT{
+					Hdr: mdns.RR_Header{Name: q.Name, Rrtype: mdns.TypeTXT, Class: mdns.ClassINET, Ttl: 60},
+					Txt: []string{val},
+				})
+			} else {
+				m.Rcode = mdns.RcodeNameError
+			}
+		}
+		_ = w.WriteMsg(m)
+	})
+
+	server := &mdns.Server{PacketConn: conn, Handler: handler, Net: "udp"}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+
+	return conn.LocalAddr().String()
+}
+
+func TestLookupDKIMUserSelectorHit(t *testing.T) {
+	domain := "example.com"
+	resolver := startDKIMServer(t, domain, map[string]string{
+		"custom": "v=DKIM1; k=rsa; p=PUBKEY",
+	})
+
+	got := lookupDKIM(domain, []string{"custom", "default"}, resolver)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 DKIM record, got %d", len(got))
+	}
+	if got[0].Selector != "custom" {
+		t.Errorf("selector: got %q, want %q", got[0].Selector, "custom")
+	}
+	if !strings.Contains(strings.ToLower(got[0].Value), "v=dkim1") {
+		t.Errorf("value missing v=dkim1: %q", got[0].Value)
+	}
+}
+
+func TestLookupDKIMPreservesSelectorOrder(t *testing.T) {
+	domain := "example.com"
+	resolver := startDKIMServer(t, domain, map[string]string{
+		"google":  "v=DKIM1; k=rsa; p=A",
+		"custom":  "v=DKIM1; k=rsa; p=B",
+		"default": "v=DKIM1; k=rsa; p=C",
+	})
+
+	// Order: user-supplied "custom" first, then built-ins "default", "google".
+	selectors := mergeDKIMSelectors([]string{"custom"}, []string{"default", "google"})
+	got := lookupDKIM(domain, selectors, resolver)
+
+	want := []string{"custom", "default", "google"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d records, got %d", len(want), len(got))
+	}
+	for i, sel := range want {
+		if got[i].Selector != sel {
+			t.Errorf("position %d: got %q, want %q", i, got[i].Selector, sel)
+		}
+	}
+}
+
+func TestSelectorsFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{name: "unset", env: "", want: nil},
+		{name: "single value", env: "foo", want: []string{"foo"}},
+		{name: "comma separated", env: "foo,bar,baz", want: []string{"foo", "bar", "baz"}},
+		{name: "trims whitespace and drops empties", env: " foo , , bar ,", want: []string{"foo", "bar"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(DKIMSelectorsEnvVar, tc.env)
+			got := selectorsFromEnv()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("selectorsFromEnv() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLookupDKIMSkipsNonDKIMTXT(t *testing.T) {
+	domain := "example.com"
+	resolver := startDKIMServer(t, domain, map[string]string{
+		"foo": "not a dkim record",
+		"bar": "v=DKIM1; k=rsa; p=PUBKEY",
+	})
+
+	got := lookupDKIM(domain, []string{"foo", "bar"}, resolver)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 DKIM record, got %d", len(got))
+	}
+	if got[0].Selector != "bar" {
+		t.Errorf("selector: got %q, want %q", got[0].Selector, "bar")
 	}
 }
 


### PR DESCRIPTION
Adds `--dkim-selector` (repeatable / comma-separated) and a `QUIEN_DKIM_SELECTORS` env var so users can probe selectors that aren't in the built-in common list. User-supplied selectors are probed in addition to the built-ins, not instead of them.

Closes #31