### PR TITLE
Add TLD extension fields and .au WHOIS support

### DIFF
--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -263,9 +263,6 @@ func section(title string) string {
 }
 
 func renderExtensions(title string, ext map[string]string) string {
-	if title == "" {
-		title = "Extensions"
-	}
 	var b strings.Builder
 	b.WriteString(section(title))
 	keys := make([]string, 0, len(ext))

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -3,6 +3,7 @@ package display
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -148,6 +149,11 @@ func RenderWhois(info model.DomainInfo) string {
 		b.WriteString(renderContact(contact))
 	}
 
+	if len(info.Extensions) > 0 {
+		b.WriteString("\n")
+		b.WriteString(renderExtensions(info.ExtensionSection, info.Extensions))
+	}
+
 	return b.String()
 }
 
@@ -254,6 +260,23 @@ func section(title string) string {
 	}
 	line := dividerStyle.Render(strings.Repeat("─", lineWidth))
 	return label + " " + line + "\n"
+}
+
+func renderExtensions(title string, ext map[string]string) string {
+	if title == "" {
+		title = "Extensions"
+	}
+	var b strings.Builder
+	b.WriteString(section(title))
+	keys := make([]string, 0, len(ext))
+	for k := range ext {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		b.WriteString(row(k, ext[k]))
+	}
+	return b.String()
 }
 
 func renderContact(c model.Contact) string {

--- a/internal/model/domain.go
+++ b/internal/model/domain.go
@@ -3,16 +3,18 @@ package model
 import "time"
 
 type DomainInfo struct {
-	DomainName  string    `json:"domain_name"`
-	Registrar   string    `json:"registrar,omitempty"`
-	Status      []string  `json:"status,omitempty"`
-	CreatedDate time.Time `json:"created_date,omitempty"`
-	UpdatedDate time.Time `json:"updated_date,omitempty"`
-	ExpiryDate  time.Time `json:"expiry_date,omitempty"`
-	Nameservers []string  `json:"nameservers,omitempty"`
-	DNSSEC      bool      `json:"dnssec"`
-	Contacts    []Contact `json:"contacts,omitempty"`
-	RawResponse string    `json:"-"`
+	DomainName       string            `json:"domain_name"`
+	Registrar        string            `json:"registrar,omitempty"`
+	Status           []string          `json:"status,omitempty"`
+	CreatedDate      time.Time         `json:"created_date,omitempty"`
+	UpdatedDate      time.Time         `json:"updated_date,omitempty"`
+	ExpiryDate       time.Time         `json:"expiry_date,omitempty"`
+	Nameservers      []string          `json:"nameservers,omitempty"`
+	DNSSEC           bool              `json:"dnssec"`
+	Contacts         []Contact         `json:"contacts,omitempty"`
+	Extensions       map[string]string `json:"extensions,omitempty"`
+	ExtensionSection string            `json:"extension_section,omitempty"`
+	RawResponse      string            `json:"-"`
 }
 
 type Contact struct {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -105,4 +105,8 @@ func mergeFromWhois(info *model.DomainInfo, w *model.DomainInfo) {
 	if len(info.Contacts) == 0 {
 		info.Contacts = w.Contacts
 	}
+	if len(info.Extensions) == 0 && len(w.Extensions) > 0 {
+		info.Extensions = w.Extensions
+		info.ExtensionSection = w.ExtensionSection
+	}
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -91,6 +91,26 @@ func TestMergeFromWhois_RDAPWinsWhereBothHaveData(t *testing.T) {
 	}
 }
 
+func TestMergeFromWhois_PropagatesExtensions(t *testing.T) {
+	info := &model.DomainInfo{DomainName: "auda.org.au"}
+	w := &model.DomainInfo{
+		Extensions:       map[string]string{"Registrant": "Example Pty Ltd", "Type": "Company"},
+		ExtensionSection: "Eligibility",
+	}
+
+	mergeFromWhois(info, w)
+
+	if len(info.Extensions) != 2 {
+		t.Errorf("Extensions len = %d, want 2", len(info.Extensions))
+	}
+	if info.Extensions["Registrant"] != "Example Pty Ltd" {
+		t.Errorf("Extensions[Registrant] = %q, want Example Pty Ltd", info.Extensions["Registrant"])
+	}
+	if info.ExtensionSection != "Eligibility" {
+		t.Errorf("ExtensionSection = %q, want Eligibility", info.ExtensionSection)
+	}
+}
+
 func TestMergeFromWhois_EmptyWhoisIsNoOp(t *testing.T) {
 	info := &model.DomainInfo{
 		DomainName: "example.com",

--- a/internal/whois/parser.go
+++ b/internal/whois/parser.go
@@ -45,9 +45,9 @@ func Parse(raw string) model.DomainInfo {
 	dnssec := strings.ToLower(firstValue(kv, "dnssec"))
 	info.DNSSEC = dnssec == "signeddelegation" || dnssec == "yes" || dnssec == "signed"
 
-	info.Extensions = ExtractExtensions(info.DomainName, kv)
+	info.Extensions = extractExtensions(info.DomainName, kv)
 	if len(info.Extensions) > 0 {
-		info.ExtensionSection = ExtensionSection(info.DomainName)
+		info.ExtensionSection = extensionSection(info.DomainName)
 	}
 
 	// Extract contacts

--- a/internal/whois/parser.go
+++ b/internal/whois/parser.go
@@ -45,6 +45,11 @@ func Parse(raw string) model.DomainInfo {
 	dnssec := strings.ToLower(firstValue(kv, "dnssec"))
 	info.DNSSEC = dnssec == "signeddelegation" || dnssec == "yes" || dnssec == "signed"
 
+	info.Extensions = ExtractExtensions(info.DomainName, kv)
+	if len(info.Extensions) > 0 {
+		info.ExtensionSection = ExtensionSection(info.DomainName)
+	}
+
 	// Extract contacts
 	registrant := extractContact(kv, "registrant", "registrant")
 	if registrant.Name != "" || registrant.Organization != "" || registrant.Email != "" {

--- a/internal/whois/tlds.go
+++ b/internal/whois/tlds.go
@@ -15,6 +15,12 @@ type tldConfig struct {
 	// normalize rewrites a raw response into the generic "key: value" form
 	// the parser expects. Nil = pass through unchanged.
 	normalize func(raw string) string
+	// extensionKeys maps a lowercase WHOIS key (as produced by extractKeyValues)
+	// to the display label stored in DomainInfo.Extensions. Nil = no extras.
+	extensionKeys map[string]string
+	// extensionSection is the section heading used when rendering Extensions.
+	// Empty = use the default "Extensions".
+	extensionSection string
 }
 
 // tlds is the single source of truth for TLD-specific WHOIS quirks.
@@ -33,6 +39,21 @@ var tlds = map[string]tldConfig{
 		normalize:   normalizeJPRS,
 	},
 	// .co.jp, .ne.jp, etc. all use the same JPRS server.
+	// auDA returns standard key: value format; the three fields below describe
+	// the registrant entity (the legal body holding the domain) and are distinct
+	// from the contact-person fields (Registrant Contact Name, etc.).
+	"au": {
+		server:           "whois.auda.org.au",
+		extensionSection: "Eligibility",
+		// "eligibility type" is labelled "Type" rather than "Eligibility Type"
+		// because labelWidth=14 would truncate the longer form; the section
+		// heading already provides the "Eligibility" context.
+		extensionKeys: map[string]string{
+			"registrant":       "Registrant",
+			"registrant id":    "Registrant ID",
+			"eligibility type": "Type",
+		},
+	},
 }
 
 // Normalize applies any TLD-specific transformation that brings the raw
@@ -66,6 +87,35 @@ var jprsLabelLine = regexp.MustCompile(`^\s*(?:[a-z]\.\s+)?\[([^\s\]][^\]]*)\]\s
 // a generic name need to appear here.
 var jprsLabelRenames = map[string]string{
 	"state": "Status", // JPRS uses "State" for domain lifecycle (Connected/...)
+}
+
+// ExtractExtensions returns TLD-specific key-value pairs from the parsed WHOIS
+// key-value map. Returns nil if the TLD has no extension keys configured or
+// none of the keys appear in the response.
+func ExtractExtensions(domain string, kv map[string][]string) map[string]string {
+	cfg, ok := tlds[tldOf(domain)]
+	if !ok || len(cfg.extensionKeys) == 0 {
+		return nil
+	}
+	result := make(map[string]string)
+	for kvKey, label := range cfg.extensionKeys {
+		if vals := kv[kvKey]; len(vals) > 0 {
+			result[label] = vals[0]
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// ExtensionSection returns the display heading for the extensions block.
+// Falls back to "Extensions" when the TLD has no custom section name.
+func ExtensionSection(domain string) string {
+	if cfg, ok := tlds[tldOf(domain)]; ok && cfg.extensionSection != "" {
+		return cfg.extensionSection
+	}
+	return "Extensions"
 }
 
 func normalizeJPRS(raw string) string {

--- a/internal/whois/tlds.go
+++ b/internal/whois/tlds.go
@@ -89,10 +89,10 @@ var jprsLabelRenames = map[string]string{
 	"state": "Status", // JPRS uses "State" for domain lifecycle (Connected/...)
 }
 
-// ExtractExtensions returns TLD-specific key-value pairs from the parsed WHOIS
+// extractExtensions returns TLD-specific key-value pairs from the parsed WHOIS
 // key-value map. Returns nil if the TLD has no extension keys configured or
 // none of the keys appear in the response.
-func ExtractExtensions(domain string, kv map[string][]string) map[string]string {
+func extractExtensions(domain string, kv map[string][]string) map[string]string {
 	cfg, ok := tlds[tldOf(domain)]
 	if !ok || len(cfg.extensionKeys) == 0 {
 		return nil
@@ -109,9 +109,9 @@ func ExtractExtensions(domain string, kv map[string][]string) map[string]string 
 	return result
 }
 
-// ExtensionSection returns the display heading for the extensions block.
+// extensionSection returns the display heading for the extensions block.
 // Falls back to "Extensions" when the TLD has no custom section name.
-func ExtensionSection(domain string) string {
+func extensionSection(domain string) string {
 	if cfg, ok := tlds[tldOf(domain)]; ok && cfg.extensionSection != "" {
 		return cfg.extensionSection
 	}

--- a/internal/whois/tlds_test.go
+++ b/internal/whois/tlds_test.go
@@ -106,6 +106,70 @@ s. [Signing Key]
 	}
 }
 
+func TestAUExtensions(t *testing.T) {
+	raw := `Domain Name: auda.org.au
+Last Modified: 2023-07-05T00:23:15Z
+Registrar Name: auDA
+Status: serverDeleteProhibited https://identitydigital.au/whois-status-codes#serverDeleteProhibited
+Registrant Contact ID: 5b8528848e1b48ddbf62fa592f627c57-AU
+Registrant Contact Name: CEO
+Tech Contact ID: 5b8528848e1b48ddbf62fa592f627c57-AU
+Tech Contact Name: CEO
+Name Server: ingrid.ns.cloudflare.com
+Name Server: karl.ns.cloudflare.com
+DNSSEC: signedDelegation
+Registrant: .au Domain Administration Ltd
+Registrant ID: ACN 079 009 340
+Eligibility Type: Company`
+
+	info := Parse(raw)
+
+	// Standard fields must still work.
+	if info.Registrar != "auDA" {
+		t.Errorf("Registrar = %q, want auDA", info.Registrar)
+	}
+	if info.UpdatedDate.Year() != 2023 {
+		t.Errorf("UpdatedDate year = %d, want 2023", info.UpdatedDate.Year())
+	}
+	if len(info.Status) != 1 || info.Status[0] != "serverDeleteProhibited" {
+		t.Errorf("Status = %v, want [serverDeleteProhibited]", info.Status)
+	}
+	if len(info.Nameservers) != 2 {
+		t.Errorf("Nameservers count = %d, want 2", len(info.Nameservers))
+	}
+	if !info.DNSSEC {
+		t.Error("DNSSEC should be true for signedDelegation")
+	}
+
+	// Contact person fields must not be overwritten by the entity fields.
+	var regName, techName string
+	for _, c := range info.Contacts {
+		switch c.Role {
+		case "registrant":
+			regName = c.Name
+		case "tech":
+			techName = c.Name
+		}
+	}
+	if regName != "CEO" {
+		t.Errorf("registrant contact name = %q, want CEO", regName)
+	}
+	if techName != "CEO" {
+		t.Errorf("tech contact name = %q, want CEO", techName)
+	}
+
+	// Entity extensions must be captured.
+	if got := info.Extensions["Registrant"]; got != ".au Domain Administration Ltd" {
+		t.Errorf("Extensions[Registrant] = %q, want .au Domain Administration Ltd", got)
+	}
+	if got := info.Extensions["Registrant ID"]; got != "ACN 079 009 340" {
+		t.Errorf("Extensions[Registrant ID] = %q, want ACN 079 009 340", got)
+	}
+	if got := info.Extensions["Type"]; got != "Company" {
+		t.Errorf("Extensions[Type] = %q, want Company", got)
+	}
+}
+
 func TestCleanReferralHost(t *testing.T) {
 	tests := map[string]string{
 		// Bare hostname — unchanged.


### PR DESCRIPTION
Introduces a generic extension mechanism for capturing WHOIS fields that are registry-specific and have no equivalent in the standard DomainInfo model. Each TLD can declare a set of extra keys to extract via extensionKeys in tldConfig; the results are stored in DomainInfo.Extensions (map[string]string) and rendered as a named section in the output.

The section heading is also configurable per TLD via extensionSection, defaulting to "Extensions" when unset. Display uses a new renderExtensions() helper consistent with renderContact().

Adds .au support (whois.auda.org.au) as the first user of this mechanism. auDA's WHOIS format is standard key: value but includes three fields that describe the registrant legal entity rather than the contact person — these are intentionally separate from Registrant Contact Name / Registrant Contact ID which the generic parser already handles:

  Registrant:      legal entity name (e.g. company or individual)
  Registrant ID:   ACN or ABN identifier
  Eligibility Type: registration eligibility class (Company, etc.)

These are rendered under an "Eligibility" section heading. The single "au" tldConfig entry covers all second-level .au domains (com.au, net.au, org.au, etc.) since tldOf() extracts only the rightmost label.

Extensions and their section name are propagated through the RDAP+WHOIS merge path in resolver.mergeFromWhois so they surface correctly when RDAP is the primary data source.