### PR TITLE
Add HTTPS (SVCB) resource record reporting to the DNS panel

### DIFF
--- a/internal/display/dns.go
+++ b/internal/display/dns.go
@@ -45,6 +45,15 @@ func RenderDNS(records *dns.Records) string {
 		}
 	}
 
+	if len(records.HTTPS) > 0 {
+		hasRecords = true
+		b.WriteString("\n")
+		b.WriteString(section("HTTPS"))
+		for _, h := range records.HTTPS {
+			b.WriteString(renderHTTPSRecord(h))
+		}
+	}
+
 	if len(records.MX) > 0 {
 		hasRecords = true
 		b.WriteString("\n")
@@ -109,6 +118,56 @@ func RenderDNS(records *dns.Records) string {
 	if !hasRecords {
 		b.WriteString(dimStyle.Render("  No records found"))
 		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// renderHTTPSRecord renders a single HTTPS (SVCB) record. Priority 0 is alias
+// mode and only carries a target; otherwise the SvcParams are listed. A target
+// of "." (the owner name itself) is the common case and shown without a header.
+func renderHTTPSRecord(h dns.HTTPSRecord) string {
+	var b strings.Builder
+
+	target := h.Target
+	if target == "." {
+		target = ""
+	}
+
+	if h.Priority == 0 {
+		alias := dimStyle.Render("alias → ")
+		if target == "" {
+			return row("", alias+dimStyle.Render("(self)"))
+		}
+		return row("", alias+nsStyle.Render(target))
+	}
+
+	// Service mode: always emit an identity row so priority is visible and
+	// multiple records stay visually separated, even for the common "." target.
+	pri := dimStyle.Render(fmt.Sprintf("(%d)", h.Priority))
+	if target == "" {
+		b.WriteString(row("", dimStyle.Render("(self)")+" "+pri))
+	} else {
+		b.WriteString(row("", nsStyle.Render(target)+" "+pri))
+	}
+
+	if len(h.ALPN) > 0 {
+		b.WriteString(row("alpn", strings.Join(h.ALPN, ", ")))
+	}
+	if h.Port != 0 {
+		b.WriteString(row("port", fmt.Sprintf("%d", h.Port)))
+	}
+	for _, ip := range h.IPv4Hint {
+		b.WriteString(row("ipv4hint", nsStyle.Render(ip)))
+	}
+	for _, ip := range h.IPv6Hint {
+		b.WriteString(row("ipv6hint", nsStyle.Render(ip)))
+	}
+	if h.ECHConfig != "" {
+		b.WriteString(row("ech", lipgloss.NewStyle().Foreground(green).Render("present")))
+	}
+	for _, p := range h.Params {
+		b.WriteString(row("", dimStyle.Render(p)))
 	}
 
 	return b.String()

--- a/internal/display/dns_test.go
+++ b/internal/display/dns_test.go
@@ -1,0 +1,56 @@
+package display
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/retlehs/quien/internal/dns"
+)
+
+func TestRenderHTTPSRecord(t *testing.T) {
+	tests := []struct {
+		name    string
+		record  dns.HTTPSRecord
+		want    []string // substrings expected in the output
+		notWant []string
+	}{
+		{
+			name: "service mode self target shows priority and self",
+			record: dns.HTTPSRecord{
+				Priority:  1,
+				Target:    ".",
+				ALPN:      []string{"h3", "h2"},
+				IPv4Hint:  []string{"104.16.132.229"},
+				ECHConfig: "AAE=",
+			},
+			want: []string{"(self)", "(1)", "alpn", "h3, h2", "ipv4hint", "104.16.132.229", "ech", "present"},
+		},
+		{
+			name:    "alias mode shows target",
+			record:  dns.HTTPSRecord{Priority: 0, Target: "svc.example.net"},
+			want:    []string{"alias", "svc.example.net"},
+			notWant: []string{"alpn", "(self)"},
+		},
+		{
+			name:   "service mode named target shows target and priority",
+			record: dns.HTTPSRecord{Priority: 16, Target: "svc.example.net", Port: 8443},
+			want:   []string{"svc.example.net", "(16)", "port", "8443"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderHTTPSRecord(tt.record)
+			for _, sub := range tt.want {
+				if !strings.Contains(got, sub) {
+					t.Errorf("output missing %q\ngot:\n%s", sub, got)
+				}
+			}
+			for _, sub := range tt.notWant {
+				if strings.Contains(got, sub) {
+					t.Errorf("output unexpectedly contains %q\ngot:\n%s", sub, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -14,12 +14,27 @@ type Records struct {
 	A      []string
 	AAAA   []string
 	CNAME  []string
+	HTTPS  []HTTPSRecord
 	MX     []MXRecord
 	NS     []string
 	TXT    []string
 	PTR    []PTRRecord
 	SOA    *SOARecord
 	DNSSEC bool
+}
+
+// HTTPSRecord is an HTTPS (SVCB-family) resource record (RFC 9460).
+// Priority 0 is alias mode; a non-zero priority is service mode and
+// carries the SvcParams below. A Target of "." means the owner name.
+type HTTPSRecord struct {
+	Priority  uint16
+	Target    string
+	ALPN      []string
+	Port      uint16
+	IPv4Hint  []string
+	IPv6Hint  []string
+	ECHConfig string   // base64 ECHConfigList, empty when absent
+	Params    []string // other/unknown SvcParams as "key=value"
 }
 
 type PTRRecord struct {
@@ -111,6 +126,10 @@ func Lookup(domain string) (*Records, error) {
 		}
 	}
 
+	if rr, err := query(domain, mdns.TypeHTTPS, resolver); err == nil {
+		records.HTTPS = parseHTTPS(rr)
+	}
+
 	if rr, err := query(domain, mdns.TypeMX, resolver); err == nil {
 		for _, r := range rr {
 			if mx, ok := r.(*mdns.MX); ok {
@@ -180,6 +199,48 @@ func Lookup(domain string) (*Records, error) {
 	}
 
 	return records, nil
+}
+
+// parseHTTPS extracts the SvcParams from HTTPS (SVCB) resource records into a
+// display-friendly form. Well-known keys (ALPN, port, IP hints, ECH) get their
+// own fields; anything else is preserved verbatim in Params.
+func parseHTTPS(rr []mdns.RR) []HTTPSRecord {
+	var out []HTTPSRecord
+	for _, r := range rr {
+		h, ok := r.(*mdns.HTTPS)
+		if !ok {
+			continue
+		}
+		rec := HTTPSRecord{Priority: h.Priority, Target: h.Target}
+		if rec.Target != "." {
+			rec.Target = strings.TrimSuffix(rec.Target, ".")
+		}
+		for _, kv := range h.Value {
+			switch v := kv.(type) {
+			case *mdns.SVCBAlpn:
+				rec.ALPN = v.Alpn
+			case *mdns.SVCBPort:
+				rec.Port = v.Port
+			case *mdns.SVCBIPv4Hint:
+				for _, ip := range v.Hint {
+					rec.IPv4Hint = append(rec.IPv4Hint, ip.String())
+				}
+			case *mdns.SVCBIPv6Hint:
+				for _, ip := range v.Hint {
+					rec.IPv6Hint = append(rec.IPv6Hint, ip.String())
+				}
+			case *mdns.SVCBECHConfig:
+				rec.ECHConfig = v.String()
+			default:
+				rec.Params = append(rec.Params, kv.Key().String()+"="+kv.String())
+			}
+		}
+		out = append(out, rec)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Priority < out[j].Priority
+	})
+	return out
 }
 
 func query(domain string, qtype uint16, resolver string) ([]mdns.RR, error) {

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"net"
+	"slices"
 	"testing"
 
 	mdns "github.com/miekg/dns"
@@ -111,6 +112,77 @@ func TestQueryUDPSuccessSkipsTCPFallback(t *testing.T) {
 	}
 	if len(rr) != 1 {
 		t.Fatalf("expected 1 answer, got %d", len(rr))
+	}
+}
+
+func TestParseHTTPS(t *testing.T) {
+	hdr := mdns.RR_Header{Name: "example.com.", Rrtype: mdns.TypeHTTPS, Class: mdns.ClassINET, Ttl: 300}
+
+	service := &mdns.HTTPS{SVCB: mdns.SVCB{
+		Hdr:      hdr,
+		Priority: 2,
+		Target:   ".",
+		Value: []mdns.SVCBKeyValue{
+			&mdns.SVCBAlpn{Alpn: []string{"h3", "h2"}},
+			&mdns.SVCBPort{Port: 8443},
+			&mdns.SVCBIPv4Hint{Hint: []net.IP{net.ParseIP("192.0.2.1")}},
+			&mdns.SVCBIPv6Hint{Hint: []net.IP{net.ParseIP("2001:db8::1")}},
+			&mdns.SVCBECHConfig{ECH: []byte{0x00, 0x01}},
+			&mdns.SVCBMandatory{Code: []mdns.SVCBKey{mdns.SVCB_ALPN}},
+		},
+	}}
+	alias := &mdns.HTTPS{SVCB: mdns.SVCB{
+		Hdr:      hdr,
+		Priority: 0,
+		Target:   "svc.example.net.",
+	}}
+
+	// Pass the higher-priority record first to confirm sorting by priority.
+	got := parseHTTPS([]mdns.RR{service, alias})
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(got))
+	}
+
+	// Alias (priority 0) should sort ahead of the service record.
+	if got[0].Priority != 0 || got[0].Target != "svc.example.net" {
+		t.Errorf("record[0] = %+v, want alias mode targeting svc.example.net", got[0])
+	}
+
+	svc := got[1]
+	if svc.Priority != 2 {
+		t.Errorf("priority = %d, want 2", svc.Priority)
+	}
+	if svc.Target != "." {
+		t.Errorf("target = %q, want \".\" (self)", svc.Target)
+	}
+	if want := []string{"h3", "h2"}; !slices.Equal(svc.ALPN, want) {
+		t.Errorf("alpn = %v, want %v", svc.ALPN, want)
+	}
+	if svc.Port != 8443 {
+		t.Errorf("port = %d, want 8443", svc.Port)
+	}
+	if want := []string{"192.0.2.1"}; !slices.Equal(svc.IPv4Hint, want) {
+		t.Errorf("ipv4hint = %v, want %v", svc.IPv4Hint, want)
+	}
+	if want := []string{"2001:db8::1"}; !slices.Equal(svc.IPv6Hint, want) {
+		t.Errorf("ipv6hint = %v, want %v", svc.IPv6Hint, want)
+	}
+	if svc.ECHConfig != "AAE=" {
+		t.Errorf("ech config = %q, want base64 of {0x00,0x01}", svc.ECHConfig)
+	}
+	if want := []string{"mandatory=alpn"}; !slices.Equal(svc.Params, want) {
+		t.Errorf("params = %v, want %v", svc.Params, want)
+	}
+}
+
+func TestParseHTTPSIgnoresNonHTTPS(t *testing.T) {
+	a := &mdns.A{
+		Hdr: mdns.RR_Header{Name: "example.com.", Rrtype: mdns.TypeA, Class: mdns.ClassINET, Ttl: 60},
+		A:   net.ParseIP("192.0.2.1"),
+	}
+	if got := parseHTTPS([]mdns.RR{a}); got != nil {
+		t.Errorf("expected nil for non-HTTPS records, got %v", got)
 	}
 }
 


### PR DESCRIPTION
Closes #36.

Reports HTTPS resource records (RFC 9460) in DNS lookups, surfacing the SvcParams operators care about: ALPN (HTTP/2, HTTP/3 support), target, priority, port, IPv4/IPv6 hints, and ECH config presence. Records show up in the DNS panel and flow into `quien dns` / `quien all` JSON automatically.