### PR TITLE
Add support for multiple sitemap entries

### DIFF
--- a/internal/display/seo.go
+++ b/internal/display/seo.go
@@ -76,12 +76,12 @@ func renderIndexability(b *strings.Builder, idx *seo.Indexability) {
 	}
 
 	if idx.SitemapFound {
-		b.WriteString(row("Sitemap", foundStyle.Render("found")))
-		if idx.SitemapURL != "" {
-			b.WriteString(row("", dimStyle.Render(idx.SitemapURL)))
+		b.WriteString(row("Sitemaps", foundStyle.Render("found")))
+		for _, u := range idx.SitemapURLs {
+			b.WriteString(row("", dimStyle.Render(u)))
 		}
 	} else {
-		b.WriteString(row("Sitemap", notFoundStyle.Render("not found")))
+		b.WriteString(row("Sitemaps", notFoundStyle.Render("not found")))
 	}
 }
 

--- a/internal/seo/seo.go
+++ b/internal/seo/seo.go
@@ -25,13 +25,13 @@ type Result struct {
 }
 
 type Indexability struct {
-	RobotsTxt    string `json:"robots_txt,omitempty"`
-	RobotsMeta   string `json:"robots_meta,omitempty"`
-	XRobotsTag   string `json:"x_robots_tag,omitempty"`
-	Canonical    string `json:"canonical,omitempty"`
-	Indexable    bool   `json:"indexable"`
-	SitemapFound bool   `json:"sitemap_found"`
-	SitemapURL   string `json:"sitemap_url,omitempty"`
+	RobotsTxt    string   `json:"robots_txt,omitempty"`
+	RobotsMeta   string   `json:"robots_meta,omitempty"`
+	XRobotsTag   string   `json:"x_robots_tag,omitempty"`
+	Canonical    string   `json:"canonical,omitempty"`
+	Indexable    bool     `json:"indexable"`
+	SitemapFound bool     `json:"sitemap_found"`
+	SitemapURLs  []string `json:"sitemap_urls,omitempty"`
 }
 
 type OnPage struct {
@@ -166,19 +166,21 @@ func fetchRobotsTxt(r *Result, client *http.Client, baseURL string) {
 			url := strings.TrimSpace(trimmed[len("sitemap:"):])
 			if url != "" {
 				r.Indexability.SitemapFound = true
-				r.Indexability.SitemapURL = url
-				return
+				r.Indexability.SitemapURLs = append(r.Indexability.SitemapURLs, url)
 			}
 		}
 	}
+	if r.Indexability.SitemapFound {
+		return
+	}
 
-	// Try well-known sitemap path if not in robots.txt
+	// Try well-known sitemap path if none declared / found in robots.txt
 	sitemapResp, err := client.Head(baseURL + "/sitemap.xml")
 	if err == nil {
 		_ = sitemapResp.Body.Close()
 		if sitemapResp.StatusCode == 200 {
 			r.Indexability.SitemapFound = true
-			r.Indexability.SitemapURL = baseURL + "/sitemap.xml"
+			r.Indexability.SitemapURLs = append(r.Indexability.SitemapURLs, baseURL+"/sitemap.xml")
 		}
 	}
 }

--- a/internal/seo/seo_test.go
+++ b/internal/seo/seo_test.go
@@ -2,6 +2,7 @@ package seo
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -365,6 +366,50 @@ func TestParseIndexability_Canonical(t *testing.T) {
 	}
 	if r.Indexability.Canonical != "https://example.com/page" {
 		t.Errorf("Canonical = %q", r.Indexability.Canonical)
+	}
+}
+
+func TestFetchRobotsTxt_MultipleSitemaps(t *testing.T) {
+	const robotsTxt = `# Robots.txt v1.0
+User-agent: *
+Disallow: /search/
+Disallow: /cart
+Allow: /store/
+
+Sitemap: https://www.example.com/store/sitemap-index.xml
+Sitemap: https://www.example.com/surface/surface.index.xml
+Sitemap: https://www.example.com/sitemaps/ai/sitemapindex.xml
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/robots.txt" {
+			_, _ = w.Write([]byte(robotsTxt))
+			return
+		}
+		http.NotFound(w, req)
+	}))
+	defer srv.Close()
+
+	r := &Result{}
+	fetchRobotsTxt(r, srv.Client(), srv.URL)
+
+	if r.Indexability.RobotsTxt != "found" {
+		t.Fatalf("RobotsTxt = %q, want \"found\"", r.Indexability.RobotsTxt)
+	}
+	if !r.Indexability.SitemapFound {
+		t.Fatal("SitemapFound = false, want true")
+	}
+	want := []string{
+		"https://www.example.com/store/sitemap-index.xml",
+		"https://www.example.com/surface/surface.index.xml",
+		"https://www.example.com/sitemaps/ai/sitemapindex.xml",
+	}
+	if len(r.Indexability.SitemapURLs) != len(want) {
+		t.Fatalf("got %d sitemaps, want %d: %v", len(r.Indexability.SitemapURLs), len(want), r.Indexability.SitemapURLs)
+	}
+	for i, w := range want {
+		if r.Indexability.SitemapURLs[i] != w {
+			t.Errorf("SitemapURLs[%d] = %q, want %q", i, r.Indexability.SitemapURLs[i], w)
+		}
 	}
 }
 


### PR DESCRIPTION
Should fix #44 

Basically I've removed an early exit and append all entries. I've also added a simple test for it.

Also tested on real website. 
For example: `x.com` has two sitemaps. 

<img width="973" height="311" alt="image" src="https://github.com/user-attachments/assets/4f9a5b17-8556-457e-9d1d-ead70c62b6eb" />
