### PR TITLE
Small fixes for CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Those values will quiet git hints about changing default branch name
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Check formatting
         run: |
           unformatted=$(gofmt -l .)


### PR DESCRIPTION
Two changes:

1. Remove requirement of cache for format step, as it doesn't download anything and uses default toolchain
2. Add global git config envs, so git wont' spam hints about coming changes to default branch name