### PR TITLE
Optimize workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -34,9 +34,9 @@ jobs:
         with:
           version: latest
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
+  checks:
+    name: Checks
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -44,19 +44,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Build
-        run: go build ./...
 
-  fmt:
-    name: Format
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: false
       - name: Check formatting
         run: |
           unformatted=$(gofmt -l .)
@@ -66,42 +54,6 @@ jobs:
             exit 1
           fi
 
-  vet:
-    name: Vet
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-      - name: Vet
-        run: go vet ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-      - name: Test
-        run: go test ./...
-
-  modernize:
-    name: Modernize
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
       - name: Check modernized code
         run: |
           go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -fix ./...
@@ -110,3 +62,6 @@ jobs:
             echo "  go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -fix ./..."
             exit 1
           fi
+          
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: Lint
+  ci:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
@@ -33,17 +32,6 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: latest
-
-  checks:
-    name: Checks
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
 
       - name: Check formatting
         run: |
@@ -62,6 +50,6 @@ jobs:
             echo "  go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -fix ./..."
             exit 1
           fi
-          
+
       - name: Test
         run: go test ./...

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -9,6 +9,8 @@ const (
 	BaseDelay   = 1 * time.Second
 )
 
+var sleep = time.Sleep
+
 // Do retries fn up to MaxAttempts times with exponential backoff.
 // Returns the result from the first successful call, or the last error.
 func Do[T any](fn func() (T, error)) (T, error) {
@@ -23,7 +25,7 @@ func Do[T any](fn func() (T, error)) (T, error) {
 
 		// Don't sleep after the last attempt
 		if attempt < MaxAttempts-1 {
-			time.Sleep(BaseDelay * time.Duration(1<<uint(attempt)))
+			sleep(BaseDelay * time.Duration(1<<attempt))
 		}
 	}
 

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -3,7 +3,11 @@ package retry
 import (
 	"errors"
 	"testing"
+	"time"
 )
+
+// Avoid backoff delays during tests.
+func init() { sleep = func(time.Duration) {} }
 
 func TestDo_SucceedsFirstTry(t *testing.T) {
 	calls := 0


### PR DESCRIPTION
While working on ci.yml yesterday found out, that most steps can be dropped, due that they are done by other commands as prerequisite. For example:

- `golangci-lint` also runs `go vet`, so a separate go vet job is unnecessary
- `go test ./... ` compiles every package, so a separate go build job is unnecessary

Entire CI as its right now can be done in one job. It will use a cache and it will be faster.

Main changes:

- Use ARM, instead of x86. Both architectures are free for open repos, but ARM a bit faster nowadays
- It would use cache for entire step, no need to re-download, re-build, re-vet and so on
- Right now 9+ seconds are wasted for retry step, as it uses time.Sleep. The trick is: we store reference to time.Sleep as package level variable and uses time.Sleep when called. But when it comes to tests, it reassigns sleep variable:

`func init() { sleep = func(time.Duration) {} }`

It's an empty function, so it would return immediately in tests (duration is zero). 

I guess your approach with 6+ steps is still good enough, but nevertheless I like optimize CI to build for prod as soon as possible.
