### PR TITLE
Fix CMS detection for Magento, PrestaShop and Webflow

### DIFF
--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -219,12 +219,18 @@ func detectCMS(r *Result, h http.Header, html string) {
 		return
 	}
 	// Magento
-	if strings.Contains(html, "/static/frontend/magento/") || strings.Contains(html, "magento_") || strings.Contains(html, "mage/") {
+	if strings.Contains(html, "/static/frontend/magento/") ||
+		strings.Contains(html, "magento_") ||
+		strings.Contains(html, "data-mage-init") ||
+		strings.Contains(html, "x-magento-init") ||
+		strings.Contains(html, "mage/cookies") {
 		r.CMS = "Magento"
 		return
 	}
 	// PrestaShop
-	if strings.Contains(html, "prestashop") || strings.Contains(html, "/modules/ps_") {
+	if strings.Contains(html, "/modules/ps_") ||
+		strings.Contains(html, "var prestashop") ||
+		strings.Contains(html, `id="prestashop"`) {
 		r.CMS = "PrestaShop"
 		return
 	}
@@ -234,7 +240,10 @@ func detectCMS(r *Result, h http.Header, html string) {
 		return
 	}
 	// Webflow
-	if strings.Contains(html, "webflow.com") || strings.Contains(html, "wf-page") {
+	if strings.Contains(html, "data-wf-page") ||
+		strings.Contains(html, "data-wf-site") ||
+		strings.Contains(html, "wf-page") ||
+		strings.Contains(html, "website-files.com") {
 		r.CMS = "Webflow"
 		return
 	}

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"net/http"
 	"slices"
 	"strings"
 	"testing"
@@ -94,6 +95,60 @@ func TestDetectWPPlugins(t *testing.T) {
 				if sliceContains(r.Plugins, nw) {
 					t.Errorf("unexpected plugin %q in %v", nw, r.Plugins)
 				}
+			}
+		})
+	}
+}
+
+func TestDetectCMS(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "Magento from data-mage-init",
+			html: `<div data-mage-init='{"someWidget":{}}'></div>`,
+			want: "Magento",
+		},
+		{
+			name: "Magento from static path",
+			html: `<link href="/static/frontend/magento/luma/en_US/css/styles.css">`,
+			want: "Magento",
+		},
+		{
+			name: "Magento not detected from image MIME types",
+			html: `<link rel="icon" type="image/png" href="/fav.png"><img src="data:image/svg+xml;base64,abc">`,
+			want: "",
+		},
+		{
+			name: "PrestaShop from module path",
+			html: `<link href="/modules/ps_shoppingcart/css/cart.css">`,
+			want: "PrestaShop",
+		},
+		{
+			name: "PrestaShop not detected from prose mention",
+			html: `<p>We migrated from prestashop last year.</p>`,
+			want: "",
+		},
+		{
+			name: "Webflow from data-wf-page",
+			html: `<html data-wf-page="abc123" data-wf-site="def456">`,
+			want: "Webflow",
+		},
+		{
+			name: "Webflow not detected from a link to webflow.com",
+			html: `<a href="https://webflow.com">Built with Webflow</a>`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Result{}
+			detectCMS(r, http.Header{}, strings.ToLower(tt.html))
+			if r.CMS != tt.want {
+				t.Errorf("expected CMS %q, got %q", tt.want, r.CMS)
 			}
 		})
 	}


### PR DESCRIPTION
Should fix #39 

Magento was detected basically on all websites, because `strings.Contains(html, "mage/")` would collide with any i<ins>**mage/**</ins>

I've also had some troubles with Prestashop `strings.Contains(html, "prestashop")` as any mention of it in body of html can make it false-positive (for example in the page about PrestaShop, but not actually using it).
I've changed it to be more precise.

Same goes to Webflow.

Websites I've used to test new rules for stack detection:

For Magento: `viewsonic.com`

````bash
./quien stack viewsonic.com
{
  "CMS": "Magento",
  "Plugins": null,
  "PoweredBy": "PHP/8.3.27",
  "Server": "nginx",
  "CDN": "Amazon CloudFront",
  "Hosting": "",
 ...
}
````

For PrestaShop: `mollybracken.com`

````bash
./quien stack mollybracken.com
{
  "CMS": "PrestaShop",
  "Plugins": null,
  "PoweredBy": "",
  "Server": "cloudflare",
  "CDN": "Cloudflare",
  "Hosting": "",
...
}
````

For WebFlow: `harness.io`

````bash
./quien stack harness.io
{
  "CMS": "Webflow",
  "Plugins": null,
  "PoweredBy": "",
  "Server": "traceable-cloud-waap",
  "CDN": "Cloudflare",
  "Hosting": "",
...
}
````

----

And `metaframe.works` to show that it doesn't give false-positive anymore, as it mentioned in issue #39 

````bash
./quien stack metaframe.works
{
  "CMS": "",
  "Plugins": null,
  "PoweredBy": "",
  "Server": "Netlify",
  "CDN": "Netlify",
  "Hosting": "",
...
}
````