### PR TITLE
Add color alternating for TXT records

### DIFF
--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -50,10 +50,11 @@ var (
 	faint  = ac("#8C959F", "#4E4E4E")
 
 	// Secondary palette tokens used across multiple files.
-	accent  = ac("#2E59A1", "#87AFFF") // nameservers, headers, DNS records
-	muted   = ac("#57606A", "#A8A8A8") // TXT records, redirect URLs, mail records
-	border  = ac("#D0D7DE", "#3A3A3A") // box and panel borders
-	tabGray = ac("#57606A", "#A0A0A0") // inactive tab text
+	accent   = ac("#2E59A1", "#87AFFF") // nameservers, headers, DNS records
+	muted    = ac("#57606A", "#A8A8A8") // TXT records, redirect URLs, mail records
+	mutedAlt = ac("#8C959F", "#7A7A7A") // alternate TXT shade for zebra striping
+	border   = ac("#D0D7DE", "#3A3A3A") // box and panel borders
+	tabGray  = ac("#57606A", "#A0A0A0") // inactive tab text
 
 	// Styles
 	domainStyle = lipgloss.NewStyle().
@@ -84,6 +85,9 @@ var (
 
 	txtStyle = lipgloss.NewStyle().
 			Foreground(muted)
+
+	txtStyleAlt = lipgloss.NewStyle().
+			Foreground(mutedAlt)
 
 	dimStyle = lipgloss.NewStyle().
 			Foreground(dim)

--- a/internal/display/dns.go
+++ b/internal/display/dns.go
@@ -77,13 +77,18 @@ func RenderDNS(records *dns.Records) string {
 		hasRecords = true
 		b.WriteString("\n")
 		b.WriteString(section("TXT"))
-		for _, txt := range records.TXT {
+		for i, txt := range records.TXT {
 			// Truncate long TXT records for display
 			display := txt
 			if len(display) > 60 {
 				display = display[:57] + "..."
 			}
-			b.WriteString(row("", txtStyle.Render(display)))
+			// Alternate shades so adjacent records are easy to tell apart.
+			style := txtStyle
+			if i%2 == 1 {
+				style = txtStyleAlt
+			}
+			b.WriteString(row("", style.Render(display)))
 		}
 	}
 


### PR DESCRIPTION
I've added alternate color for TXT records, for better read of long TXT lists.

Example would be `twitch.tv`. Right now it looks like this:

<img width="935" height="627" alt="image" src="https://github.com/user-attachments/assets/92a4027f-38da-49dc-b251-2928fe503dd1" />

With this change it would be like this:

<img width="936" height="626" alt="image" src="https://github.com/user-attachments/assets/f32c348f-949f-46b9-b0a7-421eee985066" />

Small thing, but better readability 
