### PR TITLE
Remove glibc requirement for AUR pkg build

### DIFF
--- a/packaging/aur/quien/PKGBUILD.template
+++ b/packaging/aur/quien/PKGBUILD.template
@@ -6,28 +6,22 @@ pkgdesc="A better whois and domain intelligence toolkit"
 arch=('x86_64' 'aarch64')
 url="https://github.com/retlehs/quien"
 license=('MIT')
-depends=('glibc')
 makedepends=('go')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
 sha256sums=('SHA256SUM_SOURCE')
 
 prepare() {
   cd "$pkgname-$pkgver"
-  export GOMODCACHE="${GOMODCACHE:-$srcdir/gomod}"
+  export GOMODCACHE="$srcdir/gomod"
   go mod download -modcacherw
 }
 
 build() {
   cd "$pkgname-$pkgver"
-  export CGO_CPPFLAGS="${CPPFLAGS}"
-  export CGO_CFLAGS="${CFLAGS}"
-  export CGO_CXXFLAGS="${CXXFLAGS}"
-  export CGO_LDFLAGS="${LDFLAGS}"
+  export CGO_ENABLED=0
+  export GOMODCACHE="$srcdir/gomod"
   export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
-
-  go build \
-    -ldflags="-linkmode=external -X main.version=$pkgver" \
-    -o "$pkgname"
+  go build -ldflags="-s -w -X main.version=$pkgver" -o "$pkgname"
 }
 
 check() {
@@ -40,6 +34,4 @@ package() {
   install -Dm755 "$pkgname" "$pkgdir/usr/bin/$pkgname"
   install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
   install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
-
-  go clean -modcache
 }

--- a/packaging/aur/quien/PKGBUILD.template
+++ b/packaging/aur/quien/PKGBUILD.template
@@ -20,7 +20,7 @@ build() {
   cd "$pkgname-$pkgver"
   export CGO_ENABLED=0
   export GOMODCACHE="$srcdir/gomod"
-  export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+  export GOFLAGS="-trimpath -mod=readonly -modcacherw"
   go build -ldflags="-s -w -X main.version=$pkgver" -o "$pkgname"
 }
 


### PR DESCRIPTION
Drop C library dependency from AUR build, as it's not actually used.


By `.goreleaser.yml` we don't use C at all and I've added `-s -w` to strip debug as you do already in goreleaser:

https://github.com/retlehs/quien/blob/34e5e7340ab10cd3eeac0821fc565b7df8644f70/.goreleaser.yml#L3-L7

I've tested the new PKGBUILD and it works as expected, also passes `namcap` check.

In this commit I also removed `go clean -modcache` as it can remove user's GLOBAL cache, not only in binary, if user would skip all steps and run only check() step.
Unlikely to happen, but anyway redundant as `-modcacherw` already clears cache of built package.



