### PR TITLE
Add hotkey to expand TXT records

### DIFF
--- a/internal/display/dns.go
+++ b/internal/display/dns.go
@@ -11,7 +11,7 @@ import (
 
 // RenderDNS returns a lipgloss-styled string for DNS records. nsResolutions
 // (optional) adds expanded IP/rDNS info under each NS host.
-func RenderDNS(records *dns.Records, nsResolutions []dnsutil.HostResolution) string {
+func RenderDNS(records *dns.Records, nsResolutions []dnsutil.HostResolution, txtExpanded bool) string {
 	var b strings.Builder
 
 	b.WriteString(domainSectionTitle("DNS Records"))
@@ -97,15 +97,21 @@ func RenderDNS(records *dns.Records, nsResolutions []dnsutil.HostResolution) str
 		b.WriteString("\n")
 		b.WriteString(section("TXT"))
 		for i, txt := range records.TXT {
-			// Truncate long TXT records for display
-			display := txt
-			if len(display) > 60 {
-				display = display[:57] + "..."
-			}
 			// Alternate shades so adjacent records are easy to tell apart.
 			style := txtStyle
 			if i%2 == 1 {
 				style = txtStyleAlt
+			}
+			if txtExpanded {
+				for _, line := range wrapText(txt, valueWidth()) {
+					b.WriteString(row("", style.Render(line)))
+				}
+				continue
+			}
+			// Truncate long TXT records for display
+			display := txt
+			if len(display) > 60 {
+				display = display[:57] + "..."
 			}
 			b.WriteString(row("", style.Render(display)))
 		}

--- a/internal/display/dns_test.go
+++ b/internal/display/dns_test.go
@@ -65,7 +65,7 @@ func TestRenderDNSNSResolution(t *testing.T) {
 		{Host: "ns2.example.com", Err: "no such host"},
 	}
 
-	out := RenderDNS(records, resolutions)
+	out := RenderDNS(records, resolutions, false)
 
 	for _, want := range []string{"192.0.2.1", "a.example.com", "b.example.com", "no such host"} {
 		if !strings.Contains(out, want) {
@@ -77,7 +77,7 @@ func TestRenderDNSNSResolution(t *testing.T) {
 func TestRenderDNSWithoutResolution(t *testing.T) {
 	// Passing no resolutions renders the bare NS list (default behavior).
 	records := &dns.Records{NS: []string{"ns1.example.com"}}
-	out := RenderDNS(records, nil)
+	out := RenderDNS(records, nil, false)
 	if !strings.Contains(out, "ns1.example.com") {
 		t.Errorf("RenderDNS output missing NS host\n%s", out)
 	}

--- a/internal/display/interactive.go
+++ b/internal/display/interactive.go
@@ -82,6 +82,7 @@ type Model struct {
 	nsResolved   []dnsutil.HostResolution
 	nsExpanded   bool
 	nsResolving  bool
+	txtExpanded  bool
 	mailData     *mail.Records
 	mxResolved   []dnsutil.HostResolution
 	mxExpanded   bool
@@ -328,6 +329,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		case "x":
+			if !m.isIP && m.active == tabDNS && m.dnsData != nil && len(m.dnsData.TXT) > 0 {
+				m.txtExpanded = !m.txtExpanded
+				m.updateViewport()
+				return m, nil
+			}
 			if !m.isIP && m.active == tabMail && m.mailHasSPFTree() {
 				max := spfMaxDepth(m.spfRoot())
 				switch {
@@ -342,6 +348,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		case "X":
+			if !m.isIP && m.active == tabDNS && m.dnsData != nil && len(m.dnsData.TXT) > 0 {
+				m.txtExpanded = !m.txtExpanded
+				m.updateViewport()
+				return m, nil
+			}
 			if !m.isIP && m.active == tabMail && m.mailHasSPFTree() {
 				max := spfMaxDepth(m.spfRoot())
 				if m.spfDepth == SPFExpandAll || m.spfDepth >= max {
@@ -630,7 +641,7 @@ func (m Model) contentForTab(t tab) string {
 			if m.nsExpanded {
 				res = m.nsResolved
 			}
-			return RenderDNS(m.dnsData, res)
+			return RenderDNS(m.dnsData, res, m.txtExpanded)
 		}
 	case tabTLS:
 		if m.loading {
@@ -754,6 +765,13 @@ func (m Model) View() tea.View {
 			footerParts = append(footerParts, "i collapse")
 		default:
 			footerParts = append(footerParts, "i resolve mx")
+		}
+	}
+	if !m.isIP && m.active == tabDNS && m.dnsData != nil && len(m.dnsData.TXT) > 0 {
+		if m.txtExpanded {
+			footerParts = append(footerParts, "x/X truncate txt")
+		} else {
+			footerParts = append(footerParts, "x/X full txt")
 		}
 	}
 	if !m.isIP && m.active == tabMail && m.mailHasSPFTree() {


### PR DESCRIPTION
Similarly to Mail tab I've added `x/X` hotkey to expand TXT records

Useful when you need to check full SPF record.

<img width="947" height="593" alt="image" src="https://github.com/user-attachments/assets/48ff2c24-3a26-4086-995a-0429bacc4c8b" />

---

<img width="961" height="589" alt="image" src="https://github.com/user-attachments/assets/e092b5d0-3661-4e23-8e71-5adda4d6845c" />
