### PR TITLE
Add security.txt detection with dedicated subcommand

### DIFF
--- a/cmd/all.go
+++ b/cmd/all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/retlehs/quien/internal/mail"
 	"github.com/retlehs/quien/internal/resolver"
 	"github.com/retlehs/quien/internal/retry"
+	"github.com/retlehs/quien/internal/security"
 	"github.com/retlehs/quien/internal/seo"
 	"github.com/retlehs/quien/internal/stack"
 	"github.com/retlehs/quien/internal/tlsinfo"
@@ -17,13 +18,14 @@ import (
 )
 
 type allResult struct {
-	WHOIS *any              `json:"whois,omitempty"`
-	DNS   *dns.Records      `json:"dns,omitempty"`
-	Mail  *mail.Records     `json:"mail,omitempty"`
-	TLS   *tlsinfo.CertInfo `json:"tls,omitempty"`
-	HTTP  *httpinfo.Result  `json:"http,omitempty"`
-	Stack *stack.Result     `json:"stack,omitempty"`
-	SEO   *seo.Result       `json:"seo,omitempty"`
+	WHOIS    *any              `json:"whois,omitempty"`
+	DNS      *dns.Records      `json:"dns,omitempty"`
+	Mail     *mail.Records     `json:"mail,omitempty"`
+	TLS      *tlsinfo.CertInfo `json:"tls,omitempty"`
+	HTTP     *httpinfo.Result  `json:"http,omitempty"`
+	Stack    *stack.Result     `json:"stack,omitempty"`
+	SEO      *seo.Result       `json:"seo,omitempty"`
+	Security *security.Result  `json:"security,omitempty"`
 }
 
 var allCmd = &cobra.Command{
@@ -85,6 +87,11 @@ var allCmd = &cobra.Command{
 		if page, err := retry.Do(func() (*stack.PageData, error) { return stack.FetchPage(input) }); err == nil {
 			result.Stack = stack.DetectFromPage(page.Headers, page.Body, input)
 			result.SEO = seo.AnalyzeWithPage(page, input)
+		}
+
+		// Security.txt
+		if sec, err := retry.Do(func() (*security.Result, error) { return security.Lookup(input) }); err == nil {
+			result.Security = sec
 		}
 
 		return printJSON(result)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ var dkimSelectorFlag []string
 var rootCmd = &cobra.Command{
 	Use:          "quien [domain or IP]",
 	Short:        "A better whois and domain intelligence toolkit",
-	Long:         "Inspect a domain or IP across registration (WHOIS/RDAP), DNS, mail authentication (SPF/DMARC/DKIM/BIMI), TLS, HTTP, SEO, and tech stack — interactive TUI by default, JSON via subcommands.",
+	Long:         "Inspect a domain or IP across registration (WHOIS/RDAP), DNS, mail authentication (SPF/DMARC/DKIM/BIMI), TLS, HTTP, SEO, security.txt and tech stack — interactive TUI by default, JSON via subcommands.",
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/security.go
+++ b/cmd/security.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/retlehs/quien/internal/retry"
+	"github.com/retlehs/quien/internal/security"
+	"github.com/spf13/cobra"
+)
+
+var securityCmd = &cobra.Command{
+	Use:   "security <domain>",
+	Short: "Security.txt analysis (JSON output)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		domain, err := normalizeDomain(args[0])
+		if err != nil {
+			return err
+		}
+		result, err := retry.Do(func() (*security.Result, error) {
+			return security.Lookup(domain)
+		})
+		if err != nil {
+			return fmt.Errorf("Security.txt analysis failed: %w", err)
+		}
+		return printJSON(result)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(securityCmd)
+}

--- a/internal/display/interactive.go
+++ b/internal/display/interactive.go
@@ -18,6 +18,7 @@ import (
 	"github.com/retlehs/quien/internal/rdap"
 	"github.com/retlehs/quien/internal/resolver"
 	"github.com/retlehs/quien/internal/retry"
+	"github.com/retlehs/quien/internal/security"
 	"github.com/retlehs/quien/internal/seo"
 	"github.com/retlehs/quien/internal/stack"
 	"github.com/retlehs/quien/internal/tlsinfo"
@@ -35,6 +36,7 @@ const (
 	tabHTTP
 	tabStack
 	tabSEO
+	tabSecurity
 )
 
 var (
@@ -92,12 +94,14 @@ type Model struct {
 	httpData     *httpinfo.Result
 	stackData    *stack.Result
 	seoData      *seo.Result
+	securityData *security.Result
 	dnsErr       error
 	mailErr      error
 	tlsErr       error
 	httpErr      error
 	stackErr     error
 	seoErr       error
+	securityErr  error
 	ipJumpErr    error
 	prevDomain   string
 	prevInfo     *model.DomainInfo
@@ -174,6 +178,11 @@ type stackResultMsg struct {
 
 type seoResultMsg struct {
 	result *seo.Result
+	err    error
+}
+
+type securityResultMsg struct {
+	result *security.Result
 	err    error
 }
 
@@ -464,6 +473,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateViewport()
 		return m, nil
 
+	case securityResultMsg:
+		m.setFetching(tabSecurity, false)
+		m.updateLoading()
+		m.securityData = msg.result
+		m.securityErr = msg.err
+		m.updateViewport()
+		return m, nil
+
 	case resolveIPResultMsg:
 		m.resolvingIP = false
 		m.updateLoading()
@@ -546,6 +563,10 @@ func (m *Model) activateTab(t tab) tea.Cmd {
 	case tabSEO:
 		if m.seoData == nil && m.seoErr == nil && !m.isFetching(tabSEO) {
 			cmd = fetchSEO(m.domain)
+		}
+	case tabSecurity:
+		if m.securityData == nil && m.securityErr == nil && !m.isFetching(tabSecurity) {
+			cmd = fetchSecurity(m.domain)
 		}
 	}
 	if cmd != nil {
@@ -663,6 +684,14 @@ func (m Model) contentForTab(t tab) string {
 			return errorBox("SEO Analysis Failed", m.seoErr)
 		} else if m.seoData != nil {
 			return RenderSEO(m.seoData)
+		}
+	case tabSecurity:
+		if m.loading {
+			return m.loadingText("Checking security.txt...")
+		} else if m.securityErr != nil {
+			return errorBox("security.txt Lookup Failed", m.securityErr)
+		} else if m.securityData != nil {
+			return RenderSecurity(m.securityData)
 		}
 	}
 	return ""
@@ -808,6 +837,7 @@ func (m Model) tabList() []struct {
 		{"h", "HTTP", tabHTTP},
 		{"e", "SEO", tabSEO},
 		{"t", "Stack", tabStack},
+		{"c", "Security", tabSecurity},
 	}
 }
 
@@ -1041,5 +1071,14 @@ func fetchTLS(domain string) tea.Cmd {
 			return tlsinfo.Lookup(domain)
 		})
 		return tlsResultMsg{cert: cert, err: err}
+	}
+}
+
+func fetchSecurity(domain string) tea.Cmd {
+	return func() tea.Msg {
+		result, err := retry.Do(func() (*security.Result, error) {
+			return security.Lookup(domain)
+		})
+		return securityResultMsg{result: result, err: err}
 	}
 }

--- a/internal/display/interactive_test.go
+++ b/internal/display/interactive_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/retlehs/quien/internal/dns"
+	"github.com/retlehs/quien/internal/security"
 )
 
 func TestResolveFirstIPValuePrefersCachedDNSRecords(t *testing.T) {
@@ -114,5 +116,70 @@ func TestResolveFirstIPValueUsesAAAAWhenANotPresent(t *testing.T) {
 	}
 	if ip != "2001:db8::2" {
 		t.Fatalf("resolveFirstIPValue() = %q, want %q", ip, "2001:db8::2")
+	}
+}
+
+func TestRenderSecurityNotFound(t *testing.T) {
+	t.Parallel()
+
+	result := &security.Result{Found: false}
+	output := RenderSecurity(result)
+
+	if !strings.Contains(output, "No security.txt found") {
+		t.Fatalf("expected 'No security.txt found', got:\n%s", output)
+	}
+}
+
+func TestRenderSecurityFoundWithFields(t *testing.T) {
+	t.Parallel()
+
+	result := &security.Result{
+		Found:      true,
+		URL:        "https://example.com/.well-known/security.txt",
+		StatusCode: 200,
+		Content:    "Contact: mailto:security@example.com\nPolicy: https://example.com/policy\n",
+		Fields: map[string][]string{
+			"contact": {"mailto:security@example.com"},
+			"policy":  {"https://example.com/policy"},
+		},
+	}
+	output := RenderSecurity(result)
+
+	if !strings.Contains(output, "security.txt") {
+		t.Fatal("expected title 'security.txt'")
+	}
+	if !strings.Contains(output, "Location") {
+		t.Fatal("expected section 'Location'")
+	}
+	if !strings.Contains(output, "example.com/.well-known/security.txt") {
+		t.Fatal("expected URL in output")
+	}
+	if !strings.Contains(output, "Fields") {
+		t.Fatal("expected section 'Fields'")
+	}
+	if !strings.Contains(output, "mailto:security@example.com") {
+		t.Fatal("expected contact value in output")
+	}
+	if !strings.Contains(output, "Raw Content") {
+		t.Fatal("expected section 'Raw Content'")
+	}
+}
+
+func TestRenderSecurityFoundNoFields(t *testing.T) {
+	t.Parallel()
+
+	result := &security.Result{
+		Found:   true,
+		URL:     "https://example.com/.well-known/security.txt",
+		Content: "# just a comment\n\n",
+		Fields:  map[string][]string{},
+	}
+	output := RenderSecurity(result)
+
+	if !strings.Contains(output, "security.txt") {
+		t.Fatal("expected title 'security.txt'")
+	}
+	if !strings.Contains(output, "Raw Content") {
+		t.Fatal("expected section 'Raw Content'")
 	}
 }

--- a/internal/display/security.go
+++ b/internal/display/security.go
@@ -1,0 +1,60 @@
+package display
+
+import (
+	"strings"
+
+	"github.com/retlehs/quien/internal/security"
+)
+
+func RenderSecurity(result *security.Result) string {
+	var b strings.Builder
+
+	b.WriteString(domainSectionTitle("security.txt"))
+	b.WriteString("\n\n")
+
+	if !result.Found {
+		b.WriteString(dimStyle.Render("  No security.txt found"))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	b.WriteString(section("Location"))
+	b.WriteString(row("URL", nsStyle.Render(result.URL)))
+
+	fieldOrder := []string{
+		"contact",
+		"encryption",
+		"acknowledgments",
+		"preferred-languages",
+		"canonical",
+		"policy",
+		"hiring",
+		"signature",
+	}
+
+	hasFields := false
+	for _, field := range fieldOrder {
+		if values, ok := result.Fields[field]; ok && len(values) > 0 {
+			if !hasFields {
+				b.WriteString("\n")
+				b.WriteString(section("Fields"))
+				hasFields = true
+			}
+			label := strings.Title(strings.ReplaceAll(field, "-", " "))
+			for _, v := range values {
+				b.WriteString(row(label, headerValStyle.Render(v)))
+			}
+		}
+	}
+
+	if result.Content != "" {
+		b.WriteString("\n")
+		b.WriteString(section("Raw Content"))
+		lines := strings.Split(result.Content, "\n")
+		for _, line := range lines {
+			b.WriteString(labelStyle.Render("") + "  " + dimStyle.Render(line) + "\n")
+		}
+	}
+
+	return b.String()
+}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -1,0 +1,103 @@
+package security
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Result struct {
+	Found      bool
+	URL        string
+	StatusCode int
+	Content    string
+	Fields     map[string][]string
+}
+
+const timeout = 10 * time.Second
+
+var wellKnownPaths = []string{
+	"/.well-known/security.txt",
+	"/security.txt",
+}
+
+func Lookup(domain string) (*Result, error) {
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
+			DialContext:     (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+		},
+	}
+
+	for _, path := range wellKnownPaths {
+		for _, scheme := range []string{"https", "http"} {
+			url := scheme + "://" + domain + path
+			resp, err := client.Get(url)
+			if err != nil {
+				continue
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode == http.StatusOK {
+				body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+				if err != nil {
+					return nil, err
+				}
+
+				content := string(body)
+				return &Result{
+					Found:      true,
+					URL:        url,
+					StatusCode: resp.StatusCode,
+					Content:    content,
+					Fields:     parseFields(content),
+				}, nil
+			}
+		}
+	}
+
+	return &Result{Found: false}, nil
+}
+
+// Valid security.txt fields per RFC 9116
+var validFields = map[string]bool{
+	"contact":             true,
+	"encryption":          true,
+	"preferences":         true,
+	"preferred-languages": true,
+	"hiring":              true,
+	"policy":              true,
+	"canonical":           true,
+	"acknowledgments":     true,
+}
+
+func parseFields(content string) map[string][]string {
+	fields := make(map[string][]string)
+	lines := strings.Split(content, "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(strings.ToLower(parts[0]))
+		if !validFields[key] {
+			continue
+		}
+
+		value := strings.TrimSpace(parts[1])
+		fields[key] = append(fields[key], value)
+	}
+
+	return fields
+}

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -1,0 +1,130 @@
+package security
+
+import "testing"
+
+func TestParseFieldsValidRFC9116(t *testing.T) {
+	t.Parallel()
+
+	content := `# Example security.txt
+Contact: mailto:security@example.com
+Contact: https://example.com/security.gpg
+Encryption: https://example.com/.well-known/security.pubkey
+Policy: https://example.com/security-policy
+Preferred-Languages: en, es
+Canonical: https://example.com/.well-known/security.txt
+`
+
+	fields := parseFields(content)
+
+	if len(fields) != 5 {
+		t.Fatalf("expected 5 fields, got %d", len(fields))
+	}
+
+	if vals, ok := fields["contact"]; !ok || len(vals) != 2 {
+		t.Fatalf("expected 2 contact entries, got %v", fields["contact"])
+	}
+
+	if fields["encryption"][0] != "https://example.com/.well-known/security.pubkey" {
+		t.Fatalf("unexpected encryption value: %s", fields["encryption"][0])
+	}
+
+	if fields["policy"][0] != "https://example.com/security-policy" {
+		t.Fatalf("unexpected policy value: %s", fields["policy"][0])
+	}
+}
+
+func TestParseFieldsSkipsNonStandardKeys(t *testing.T) {
+	t.Parallel()
+
+	content := `Contact: mailto:security@example.com
+Custom-Field: some-value
+X-Custom: another-value
+Policy: https://example.com/policy
+`
+
+	fields := parseFields(content)
+
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d: %v", len(fields), fields)
+	}
+
+	if _, ok := fields["custom-field"]; ok {
+		t.Fatal("should not parse non-standard key 'Custom-Field'")
+	}
+
+	if _, ok := fields["x-custom"]; ok {
+		t.Fatal("should not parse non-standard key 'X-Custom'")
+	}
+}
+
+func TestParseFieldsSkipsCommentsAndBlanks(t *testing.T) {
+	t.Parallel()
+
+	content := `# This is a comment
+Contact: mailto:test@example.com
+
+# Another comment
+
+Policy: https://example.com/policy
+`
+
+	fields := parseFields(content)
+
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d: %v", len(fields), fields)
+	}
+
+	if len(fields["contact"]) != 1 {
+		t.Fatalf("expected 1 contact, got %d", len(fields["contact"]))
+	}
+}
+
+func TestParseFieldsHandlesMalformedLines(t *testing.T) {
+	t.Parallel()
+
+	content := `Contact: mailto:test@example.com
+no-colon-here
+: empty-key
+Policy: https://example.com/policy
+`
+
+	fields := parseFields(content)
+
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d: %v", len(fields), fields)
+	}
+
+	if _, ok := fields[""]; ok {
+		t.Fatal("should not parse empty key")
+	}
+}
+
+func TestParseFieldsMultipleValuesSameKey(t *testing.T) {
+	t.Parallel()
+
+	content := `Contact: mailto:a@example.com
+Contact: mailto:b@example.com
+Contact: https://c@example.com
+`
+
+	fields := parseFields(content)
+
+	if len(fields["contact"]) != 3 {
+		t.Fatalf("expected 3 contact values, got %d", len(fields["contact"]))
+	}
+}
+
+func TestParseFieldsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	content := `CONTACT: mailto:test@example.com
+Contact: mailto:test2@example.com
+contact: mailto:test3@example.com
+`
+
+	fields := parseFields(content)
+
+	if len(fields["contact"]) != 3 {
+		t.Fatalf("expected 3 contacts (case-insensitive), got %d", len(fields["contact"]))
+	}
+}


### PR DESCRIPTION
feat: Add security.txt detection

1. Add security subcommand to independently output security.txt analysis results
2. Integrate security.txt detection into all command and interactive TUI mode
3. Update long description of root command with security.txt feature notes
4. Implement lookup, field parsing and rendering logic for security.txt